### PR TITLE
Debug option

### DIFF
--- a/nodemon.js
+++ b/nodemon.js
@@ -111,7 +111,7 @@ function readIgnoreFile() {
 }
 
 function usage() {
-  sys.print('usage: nodemon [your node app]\ne.g.: nodemon ./server.js localhost 8080\nFor details see http://github.com/remy/nodemon/\n\n');
+  sys.print('usage: nodemon [--debug] [your node app]\ne.g.: nodemon ./server.js localhost 8080\nFor details see http://github.com/remy/nodemon/\n\n');
 }
 
 if (!nodeArgs.length || nodeArgs[0] == 'help') {
@@ -122,6 +122,11 @@ if (!nodeArgs.length || nodeArgs[0] == 'help') {
 if (nodeArgs[0] == 'version') {
   sys.print('v' + meta.version + '\n');
   process.exit(0);
+}
+
+
+if (nodeArgs[0] == '--debug') {
+  app = nodeArgs[1];
 }
 
 


### PR DESCRIPTION
I've added --debug option support.

--debug option required to be first option for "node" command, so fork was needed ...

Using this option useful with node-inspector
