### PR TITLE
#!/usr/bin/env node instead of hardcoded path

### DIFF
--- a/nodemon.js
+++ b/nodemon.js
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node
+#!/usr/local/bin/env node
 var fs = require('fs'),
     sys = require('sys'),
     childProcess = require('child_process'),


### PR DESCRIPTION
currently it fails on ubuntu with npm, #!/usr/bin/env node works nicely, not sure about mac though
