### PR TITLE
nodemon wont reread nodemonignore with multiple nodemon instances

### DIFF
--- a/nodemon.js
+++ b/nodemon.js
@@ -115,7 +115,10 @@ function addIgnoreRule(line, noEscape) {
   reIgnoreFiles = new RegExp(ignoreFiles.join('|'));
 }
 
-function readIgnoreFile() {
+function readIgnoreFile(curr, prev) {
+  // unless the ignore file was actually modified, do no re-read it
+  if(curr && prev && curr.mtime.valueOf() === prev.mtime.valueOf()) return;
+
   fs.unwatchFile(ignoreFilePath);
 
   // Check if ignore file still exists. Vim tends to delete it before replacing with changed file


### PR DESCRIPTION
Checks the mtimes of curr and prev before rereading nodemonignore. fs.watchFile will fire on any access, so when a second instance of nodemon starts it will also open .nodemonignore and watchFile will fire with a modified atime.
