### PR TITLE
Resolve paths, rather than appending to cwd, for full path support.

### DIFF
--- a/nodemon.js
+++ b/nodemon.js
@@ -212,7 +212,7 @@ function getNodemonArgs() {
       app = null;
 
   for (; i < len; i++) {
-    if (existsSync(dir + '/' + args[i])) {
+    if (existsSync(path.resolve(dir, args[i]))) {
       // double check we didn't use the --watch or -w opt before this arg
       if (args[i-1] && (args[i-1] == '-w' || args[i-1] == '--watch')) {
         // ignore 


### PR DESCRIPTION
This is a full fix for [issue #78](https://github.com/remy/nodemon/issues/78)

It resolves arguments (rather than appending them to cwd), to test if they exist.  For example, prior to the patch, this would work:

```
$ nodemon debug.js
```

but this wouldn't:

```
$ nodemon /Users/jaredhanson/Projects/test/debug.js
```

This was because the `existsSync` check was testing for the existence of `/Users/jaredhanson/Projects/test//Users/jaredhanson/Projects/test/debug.js` (cwd appended to the absolute path argument).

FYI, this is being run in a directory that contains a package.json file that does not have a `main` property.
