### PR TITLE
Fixes error formatting, eliminating extra newlines caused by using util.error

### DIFF
--- a/nodemon.js
+++ b/nodemon.js
@@ -45,7 +45,7 @@ function startNode() {
   });
 
   child.stderr.on('data', function (data) {
-    util.error(data);
+    process.stderr.write(data);
   });
 
   child.on('exit', function (code, signal) {


### PR DESCRIPTION
When node crashes, and it wants to put those little ^ underneath the offending line, it writes a series of buffers that trigger the data event for stderr multiple times. util.error automatically places a new line for each buffer that's written, even though those buffers are just whitespace. This causes a ton of new lines before the carets, often pushing the actual error line off screen, which gets a bit annoying after having to scroll up for the hundredth time. By directly calling process.stderr, the buffers get written without extra newlines.
