### PR TITLE
Introduce --graceful [n] switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ The following example will listen once for the `SIGUSR2` signal (used by nodemon
 
 Note that the `process.kill` is *only* called once your shutdown jobs are complete. Hat tip to [Benjie Gillam](http://www.benjiegillam.com/2011/08/node-js-clean-restart-and-faster-development-with-nodemon/) for writing technique this up.
 
+Newly introduced nodemon --graceful [n] switch, when used, will cause nodemon to send `SIGUSR2` signal to handled script and then wait n seconds for graceful shutdown, once nodemon receive `SIGINT` signal (eg. when Ctrl-C is pressed). When --graceful switch is used without any arguments, nodemon will wait for default 5 seconds. In order for switch to work, running script should handle `SIGUSR2` for shutdown purposes but it is also required to handle `SIGINT` (because of signal propagation), following should be enough:
+
+    process.once('SIGUSR2', function () {
+      // here we initialize our shutdown task
+    });
+    process.once('SIGINT', function () {
+      // empty
+    });
 
 # Using nodemon with forever
 


### PR DESCRIPTION
Following commit introduces new --graceful [n] switch to nodemon. It will let clean shutdown not only on restart caused by code changes but also on nodemon shutting down.

If --graceful switch will be used without any arguments, once nodemon receives SIGINT (eg. Ctrl-C) it will send SIGUSR2 to the running script and wait for default 5 seconds for the script to graceful shutdown.

It is also possible to change wait time - eg. if nodemon will be started with --graceful 10 - it will wait for 10 seconds.

If the switch wont be used, default nodemon behavior will be the same as before.

In order for --graceful to work, running script must handle SIGINT (because of signal propagation) and SIGUSR2 (initializing actual shutdown). If running script is cluster based, it is advised to handle SIGINT in worker processes too.

I'll be very glad if the patch will be merged to nodemon. Im working on project that utilizes AMQP and In my case unclean shutdowns might be a bit devastating for app nodes intercommunication.
