### PR TITLE
Prevent fs.watch from starting node twice if it gets triggered multiple times.

### DIFF
--- a/nodemon.js
+++ b/nodemon.js
@@ -145,6 +145,7 @@ watchFileChecker.check = function(cb) {
     return;
   }  
   fs.watch(watchFileName, function(event, filename) {
+    if (watchFileChecker.changeDetected) { return; }
     watchFileChecker.changeDetected = true;
     cb(true);
   });


### PR DESCRIPTION
Fix #110, discussion at #113
