### PR TITLE
Fix for Issue #118

### DIFF
--- a/nodemon.js
+++ b/nodemon.js
@@ -364,8 +364,13 @@ function killNode() {
       // Force kill (/F) the whole child tree (/T) by PID (/PID 123)
       exec('taskkill /pid '+child.pid+' /T /F');
     } else {
-	  killedAfterChange = true;
-	  exec('pkill -P ' + child.pid );
+      killedAfterChange = true;
+  	  exec('pkill -P ' + child.pid, function (error, stdout, stderr) {
+  	    if (error !== null) {
+          killedAfterChange = false;
+  		    child.kill('SIGUSR2');
+  	    }
+  	  });
     }
   } else {
     startNode();


### PR DESCRIPTION
I can successfully run nodemon against coffee files:  nodemon index.coffee
I can successfully run nodemon against js files with the --debug switch:  nodemon --debug index.js
But I cannot run nodemon against coffee files with the --debug switch:  nodemon --debug index.coffee.

I understand that I'm not actually debugging coffee, but the generated js files.  The problem occurs when I change a js or coffee file and nodemon tries to restart the process:

```
debugger listening on port 5858

events.js:66
        throw arguments[1]; // Unhandled 'error' event
                   ^
Failed to open socket on port 5858, waiting 1000 ms before retrying
Error: listen EADDRINUSE
    at errnoException (net.js:776:11)
    at Server._listen2._connectionKey (net.js:917:26)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
```

The problem is that when you run coffee with the --debug option, coffee spawns an extra node process that attaches itself to port 5858 for debugger.  This is different from just running node --debug on a js file.  So there are **2** processes that need to be killed when running coffee --debug.  Since nodemon only kills one of them, when it restarts, it tries to recreate both process, but the old process is still holding on to port 5858 so it crashes.

I think the right approach is to kill the entire process tree, similar to what you are doing on windows.  I'll submit a pull request for this.
