### PR TITLE
added ability to have unescaped lines in .nodemonignore

### DIFF
--- a/nodemon.js
+++ b/nodemon.js
@@ -398,7 +398,7 @@ function readIgnoreFile(curr, prev) {
     // addIgnoreRule(flag);
     addIgnoreRule(ignoreFilePath.substring(2)); // ignore the ./ part of the filename
     fs.readFileSync(ignoreFilePath).toString().split(/\n/).forEach(function (rule, i) {
-      var noEscape = rule.substr(0,1) === ':'
+      var noEscape = rule.substr(0,1) === ':';
       if (noEscape) {
         rule = rule.substr(1);
       }


### PR DESCRIPTION
I needed to have unescaped lines in my .nodemonignore file. This pull requests checks to see if a line begins with the char ":". If it does then the : is removed and the line will not be escaped.

I'm not sure if the character : is the best choice. Does anyone have any suggestions?
