### PR TITLE
Fix a bug where only the last extension ignored files correctly

### DIFF
--- a/nodemon.js
+++ b/nodemon.js
@@ -613,7 +613,7 @@ function getAppScript(program) {
   if (program.ext.indexOf(',') !== -1 || program.ext.indexOf('*.') !== -1) {
     program.ext = program.ext.replace(/,/g, '|').split('|').map(function (item) {
       return '.' + item.replace(/^[\*\.]+/, '');
-    }).join('|');
+    }).join('$|');
   }
 }
 
@@ -729,7 +729,7 @@ if (program.options.delay) {
 
 // this is the default - why am I making it a cmd line opt?
 if (program.options.js) {
-  addIgnoreRule('^((?!\.js|\.coffee$).)*$', true); // ignores everything except JS
+  addIgnoreRule('^((?!\.js$|\.coffee$).)*$', true); // ignores everything except JS
 }
 
 if (program.options.watch && program.options.watch.length > 0) {
@@ -780,7 +780,7 @@ exists(ignoreFilePath, function (exist) {
           if (ext) {
             addIgnoreRule('^((?!' + ext + '$).)*$', true);
           } else {
-            addIgnoreRule('^((?!\.js|\.coffee$).)*$', true); // ignores everything except JS
+            addIgnoreRule('^((?!\.js$|\.coffee$).)*$', true); // ignores everything except JS
           }
         }
       }


### PR DESCRIPTION
I noticed an issue when I was using Vim. Vim makes swap files and they are named exactly like the original except with .swp at the end. The way the RegEx was being generated would only ignore the files if the extension was the last one in the list.

For example `-e js,jade,html` would only ignore html swap files, but include js and jade swap files. The generated RegEx would be as follows: `^((?!\.js|\.jade|\.html$).)*$`. As you can see, the ending line only matches the last extension. For an interactive version, check [here](http://regexpal.com/?flags=gm&regex=%5E((%3F!%5C.js%7C%5C.jade%7C%5C.html%24\).\)*%24%7C%5C.nodemonignore%7Cpublic%2F.*&input=test.js%0Atest.js.swp%0Atest.html%0Atest.html.swp%0Atest.jade%0Atest.jade.swp%0Atest.coffee%0Atest.coffee.swp%0A.nodemonignore%0A.nodemonignore.swp%0Apublic%2F).

To fix this, I just made a few changes so that the RegEx would become `^((?!\.js$|\.jade$|\.html$).)*$` and thus ignore swap files for **all** the extensions, not just the last one. To see this interactively, check [here](http://regexpal.com/?flags=gm&regex=%5E((%3F!%5C.js%24%7C%5C.jade%24%7C%5C.html%24\).\)*%24%7C%5C.nodemonignore%7Cpublic%2F.*&input=test.js%0Atest.js.swp%0Atest.html%0Atest.html.swp%0Atest.jade%0Atest.jade.swp%0Atest.coffee%0Atest.coffee.swp%0A.nodemonignore%0A.nodemonignore.swp%0Apublic%2F).

Let me know if it causes any bugs.
