### PR TITLE
Adding Literate CoffeeScript support for nodemon

### DIFF
--- a/nodemon.js
+++ b/nodemon.js
@@ -597,7 +597,7 @@ function getAppScript(program) {
     program.args = execOptions.concat(program.args);
   }
 
-  if (program.options.exec === 'node' && program.ext.indexOf('.coffee') !== -1) {
+  if (program.options.exec === 'node' && ((program.ext.indexOf('.coffee') !== -1) || (program.ext.indexOf('.litcoffee') !== -1) )) {
     program.options.exec = 'coffee';
   }
 
@@ -620,7 +620,7 @@ function getAppScript(program) {
 
     // don't override user specified extention tracking
     if (!program.options.ext) {
-      program.ext = '.coffee|.js';
+      program.ext = '.coffee|.litcoffee|.js';
     }
 
     if (!program.options.exec || program.options.exec === 'node') {
@@ -672,7 +672,7 @@ function help() {
     '',
     ' Note: if the script is omitted, nodemon will try to ',
     ' read "main" from package.json and without a .nodemonignore,',
-    ' nodemon will monitor .js and .coffee by default.',
+    ' nodemon will monitor .js, .coffee, and .litcoffee by default.',
     '',
     ' Examples:',
     '',
@@ -755,7 +755,7 @@ if (program.options.delay) {
 
 // this is the default - why am I making it a cmd line opt?
 if (program.options.js) {
-  addIgnoreRule('^((?!\.js$|\.coffee$).)*$', true); // ignores everything except JS
+  addIgnoreRule('^((?!\.js$|\.coffee|\.litcoffee$).)*$', true); // ignores everything except JS
 }
 
 if (program.options.watch && program.options.watch.length > 0) {
@@ -805,7 +805,7 @@ exists(ignoreFilePath, function (exist) {
           if (ext) {
             addIgnoreRule('^((?!' + ext + '$).)*$', true);
           } else {
-            addIgnoreRule('^((?!\.js$|\.coffee$).)*$', true); // ignores everything except JS
+            addIgnoreRule('^((?!\.js$|\.coffee|\.litcoffee$).)*$', true); // ignores everything except JS
           }
         }
       }

--- a/test/litcoffee/server.litcoffee
+++ b/test/litcoffee/server.litcoffee
@@ -1,0 +1,9 @@
+To create a very basic server the 'http' module is required.
+
+	http = require 'http'
+
+The simplest server is used for testing purposes.
+
+	server = http.createServer (req, res) -> res.end 'hi\n'
+	server.listen 8000
+	console.log "Listening on port 8000"


### PR DESCRIPTION
Hello Remy,

CoffeeScript is currently in v1.6.2 and has had support for Literate CoffeeScript (`.litcoffee` extension) support since v1.5.0. I believe that adding support for Literate CoffeeScript for `nodemon` is necessary since the Readme indicates support for CoffeeScript in general.

This change will be a major benefit to the CoffeeScript community, whose transition to Literate CoffeeScript can be even more streamlined through using nodemon.

As you have mentioned in the Readme regarding testing, I've added a test/litcoffee directory  similar to that of test/coffee that demonstrates nodemon working with Literate CoffeeScript.

On test case worth mentioning is if the user attempts to run nodemon on a litcoffee file when their version of coffee does not support litcoffee. In this case, the coffee compiler will exit with a compile error, so it should be fine.

Let me know what you think about these changes.

Sincerely,

skaushik92
