### PR TITLE
Added mention of grunt-nodemon in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ The following example will listen once for the `SIGUSR2` signal (used by nodemon
 
 Note that the `process.kill` is *only* called once your shutdown jobs are complete. Hat tip to [Benjie Gillam](http://www.benjiegillam.com/2011/08/node-js-clean-restart-and-faster-development-with-nodemon/) for writing technique this up.
 
+# Using nodemon in your [grunt.js](http://gruntjs.com) workflow
+Check out the [grunt-nodemon](https://github.com/ChrisWren/grunt-nodemon) plugin to integrate nodemon with the rest of your project's grunt workflow.
+
 # Help! My changes aren't being detected!
 
 nodemon has three potential methods it uses to look for file changes. First, it polls using the find command to search for files modified within the last second. This method works on systems with a BSD based find (Mac, for example). 


### PR DESCRIPTION
Per your tweet, I added a line in the README which makes users aware of [grunt-nodemon](https://github.com/ChrisWren/grunt-nodemon).

Thanks again for this great tool, I consider it essential when developing a node.js server!
