### PR TITLE
Adds -i or --ignore for specifying inline ignore

### DIFF
--- a/nodemon.js
+++ b/nodemon.js
@@ -552,6 +552,8 @@ function getNodemonArgs() {
       options.stdin = false;
     } else if (arg === '--ext' || arg === '-e') {
       options.ext = args.shift();
+    } else if (arg === '--ignore' || arg === '-i') {
+      options.ignore = args.shift();
     } else {
       // Remaining args are node arguments
       appargs.push(arg);
@@ -673,6 +675,8 @@ function help() {
     ' Options:',
     '',
     '  -e, --ext          extensions to look for Example: ".js|.html|.css"',
+    '  -i, --ignore       ignore paths that match the suppled RegEx.',
+    '                     E.g., "build|node_modules"',
     '  -x, --exec app     execute script with "app", ie. -x "python -v"',
     '  -q, --quiet        minimise nodemon messages to start/stop only',
     '  -w, --watch dir    watch directory "dir". use once for each',
@@ -813,7 +817,12 @@ exists(ignoreFilePath, function (exist) {
           util.log('[nodemon] detected old style .nodemonignore');
         }
         ignoreFilePath = oldIgnoreFilePath;
+        readIgnoreFile();
       } else {
+        if (program.options.ignore) {
+          addIgnoreRule(program.options.ignore);
+        }
+
         // don't create the ignorefile, just ignore the flag & JS
         // addIgnoreRule(flag);
         if (!program.options.ext) {


### PR DESCRIPTION
Also fixes a bug whereby using the old style nodemon-ignore file would result in a crash (as readIgnoreFile wasn't being called after ignoreFilePath was changed).

P.S., If you specify an ignore via ignore files or this option the default ignore rule (match anything that's JS) isn't applied. So, specifying an ignore of 'build' will result in a restart when any path that doesn't match 'build' is changed unless you also supply --js or -e 'js'. Is intended behaviour?
