### PR TITLE
Updated default watched file extensions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Now nodemon will only restart if there are changes in the `./app` or `./libs` di
 
 # Specifying extension watch list
 
-By default, nodemon looks for files with the `.js` extension. If you use the `--exec` option and monitor `app.py` nodemon will monitor files with the extension of `.py`. However, you can specify your own list with the `-e` switch like so:
+By default, nodemon looks for files with the `.js`, `.coffee`, and `.litcoffee` extensions. If you use the `--exec` option and monitor `app.py` nodemon will monitor files with the extension of `.py`. However, you can specify your own list with the `-e` switch like so:
 
     nodemon -e js,css,html
 


### PR DESCRIPTION
The README does not say that nodemon is watching `.coffee` and `.litcoffee` files by default, so I updated it.

Noticed this in the source code [here](https://github.com/remy/nodemon/blob/master/nodemon.js#L639).
