### PR TITLE
Proxy stdio to child process

### DIFF
--- a/nodemon.js
+++ b/nodemon.js
@@ -215,6 +215,7 @@ function startNode() {
     // exit the monitor, but do it gracefully
     if (signal === 'SIGUSR2') {
       // restart
+      process.stdin.pause();
       startNode();
     } else if (code === 0) { // clean exit - wait until file change to restart
       util.log('\x1B[32m[nodemon] clean exit - waiting for changes before restart\x1B[0m');


### PR DESCRIPTION
Support for command-line debugging (eg: `nodemon --exec 'node debug'`).
Ensures that escape codes get sent to the child process first.

Not tested in Node < 0.8. Do you intend to support the older versions for
long?
