### PR TITLE
Added support for coffee and litcoffee extension watching without .

### DIFF
--- a/nodemon.js
+++ b/nodemon.js
@@ -615,7 +615,7 @@ function getAppScript(program) {
     program.args = execOptions.concat(program.args);
   }
 
-  if (!program.options.forceExec && (program.options.exec === 'node' && ((program.ext.indexOf('.coffee') !== -1) || (program.ext.indexOf('.litcoffee') !== -1) ))) {
+  if (!program.options.forceExec && program.options.exec === 'node' && program.ext.indexOf('coffee') !== -1) {
     program.options.exec = 'coffee';
   }
 


### PR DESCRIPTION
In the docs for nodemon's [extension watch list option](https://github.com/remy/nodemon#specifying-extension-watch-list), it states you are allowed to omit the `.` for file extensions, but when running a CoffeeScript server, the `node` command is used instead of `coffee` because the conditional only picks up `.coffee` and `.litcoffee`.

I simply changed the conditional to accommodate both variations of the extension watch command(with and without `.`).
