### PR TITLE
Implement Istanbul for code coverage metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ results
 
 npm-debug.log
 node_modules
+coverage

--- a/package.json
+++ b/package.json
@@ -32,12 +32,13 @@
   "://main": "./bin/nodemon.js",
   "main": "./test/fixtures/app.js",
   "scripts": {
-    "test": "mocha --ui bdd --reporter spec test/**/*.test.js"
+    "test": "istanbul cover _mocha -- --ui bdd --reporter spec test/**/*.test.js"
   },
   "devDependencies": {
     "connect": "*",
     "mocha": "~1.12.0",
-    "should": "~1.2.2"
+    "should": "~1.2.2",
+    "istanbul": "~0.1.44"
   },
   "dependencies": {
     "update-notifier": "~0.1.5"


### PR DESCRIPTION
So the implementation is not as clean as it ought to be (other test frameworks should work seamlessly with Istanbul but Mocha is a bit weird - see https://github.com/gotwarlost/istanbul/issues/44).  In an ideal world the `npm test` command _should_ look like:-

```
istanbul cover mocha --ui bdd --reporter spec test/**/*.test.js
```

To see the results locally just do:

```
git clone git@github.com:matthew-andrews/nodemon.git &&
cd nodemon &&
git checkout feature/json-config &&
npm install &&
npm test &&
open coverage/lcov-report/index.html
```

(You can customise the output format:- lcov for coveralls, cobertura for Jenkins, HTML for humans)

Additionally if you want to display a badge (like this: [![Coverage Status](https://coveralls.io/repos/ftlabs/fruitmachine/badge.png?branch=master)](https://coveralls.io/r/ftlabs/fruitmachine?branch=master)) we've been _quite_ happy with coveralls.io - although the way it formats code could be a lot nicer...  (For everything other than making the image, I prefer the html outputs that Istanbul creates out of the box)

This is how we implemented coveralls for fruitmachine*...
- https://github.com/ftlabs/fruitmachine/blob/master/.travis.yml#L3
- https://github.com/ftlabs/fruitmachine/blob/master/package.json#L55
- https://github.com/ftlabs/fruitmachine/blob/master/package.json#L32

\* Our view rendering engine, like Facebook's React but we were first.  Maybe.

![coverage](https://f.cloud.github.com/assets/825088/1450864/c543fae4-4286-11e3-9157-205951beb7f1.png)

Also I would say for the record I don't think 100% code coverage is always worth aiming for...  (Especially when you're essentially working around platform/framework bugs issues - as tests aren't always going to be running in the right environment, e.g. it would be tough to test all the Windows workarounds on travis...  This is the reason\* we don't have any automated tests for [fastclick](https://github.com/ftlabs/fastclick)).

\* 75% reason, 25% excuse

Hope this is useful.
