### PR TITLE
Removed /r and /n from nodemonignore lines

### DIFF
--- a/nodemon.js
+++ b/nodemon.js
@@ -34,6 +34,7 @@ var fs = require('fs'),
     reEscComments = /\\#/g,
     reUnescapeComments = /\^\^/g, // note that '^^' is used in place of escaped comments
     reComments = /#.*$/,
+    reNewLine = /[\n\r]/,
     reTrim = /^(\s|\u00A0)+|(\s|\u00A0)+$/g,
     reEscapeChars = /[.|\-[\]()\\]/g,
     reAsterisk = /\*/g,
@@ -415,7 +416,7 @@ function addIgnoreRule(line, noEscape) {
   // remove comments and trim lines
   // this mess of replace methods is escaping "\#" to allow for emacs temp files
   if (!noEscape) {
-    if (line = line.replace(reEscComments, '^^').replace(reComments, '').replace(reUnescapeComments, '#').replace(reTrim, '')) {
+    if (line = line.replace(reNewLine,'').line.replace(reEscComments, '^^').replace(reComments, '').replace(reUnescapeComments, '#').replace(reTrim, '')) {
        ignoreFiles.push(line.replace(reEscapeChars, '\\$&').replace(reAsterisk, '.*'));
     }
   } else if (line = line.replace(reTrim, '')) {


### PR DESCRIPTION
Fixed bug in windows wherein lines in nodemonignore with comments are not processed correctly.

if my nodemonignore looks like
/.git/
/public/ #public files 
Then nodemon processes it correctly

However if my ignore file is 
/public/ #public files 
/.git/
The /public folder does not get ignore. 

Found out that this is because when the files are split by '\n', on some systems .nodemonignore is saved with \r\n as the  newline (sublime text does this). The remaining \r in the string causes the regex replaces in addIgnoreRule to fail.

I added another regex replace on \r and \n to fix this.
