### PR TITLE
Fix wrong detection when run in background in shell script

### DIFF
--- a/nodemon.js
+++ b/nodemon.js
@@ -153,7 +153,7 @@ watchFileChecker.check = function(cb) {
   }
   var watchFileName = tmpdir + seperator + 'nodemonCheckFsWatch' + Date.now();
   var watchFile = fs.openSync(watchFileName, 'w');
-  if (!watchFile) {
+  if (watchFile < 0) {
     util.log('\x1B[32m[nodemon] Unable to write to temp directory. If you experience problems with file reloading, ensure ' + tmpdir + ' is writable.\x1B[0m');
     cb(true);
     return;


### PR DESCRIPTION
Without this change, this shell script:

``` shell
#!/bin/bash
nodemon foo &
```

results in the following warning:

```
30 Nov 20:14:15 - [nodemon] watching: /tmp
30 Nov 20:14:15 - [nodemon] Unable to write to temp directory. If you experience problems with file reloading, ensure /tmp is writable.
```

In a shell script in the background, I see `watchFile` getting the value 0 (first fd available - won't have a stdin) - which is after all a valid fd.

(Ubuntu 13.10)
