### PR TITLE
Use random bytes for check file rather than time to prevent rare unlink error

### DIFF
--- a/nodemon.js
+++ b/nodemon.js
@@ -5,6 +5,7 @@
 var fs = require('fs'),
     util = require('util'),
     childProcess = require('child_process'),
+    crypto = require('crypto'),
     dirs = [],
     path = require('path'),
     exists = fs.exists || path.exists, // yay, exists moved from path to fs in 0.7.x ... :-\
@@ -151,7 +152,7 @@ watchFileChecker.check = function(cb) {
   } else {
     tmpdir = '/tmp';
   }
-  var watchFileName = tmpdir + seperator + 'nodemonCheckFsWatch' + Date.now();
+  var watchFileName = tmpdir + seperator + 'nodemonCheckFsWatch' + crypto.randomBytes(16).toString('hex');
   var watchFile = fs.openSync(watchFileName, 'w');
   if (watchFile < 0) {
     util.log('\x1B[32m[nodemon] Unable to write to temp directory. If you experience problems with file reloading, ensure ' + tmpdir + ' is writable.\x1B[0m');


### PR DESCRIPTION
Very occasionally I get this error:

```
Error: ENOENT, no such file or directory '/tmp/nodemonCheckFsWatch1386226672479'
    at Object.fs.unlinkSync (fs.js:760:18)
    at Object.watchFileChecker.check (/home/david/.nvm/v0.10.22/lib/node_modules/nodemon/nodemon.js:167:6)
    at ready (/home/david/.nvm/v0.10.22/lib/node_modules/nodemon/nodemon.js:49:22)
    at /home/david/.nvm/v0.10.22/lib/node_modules/nodemon/nodemon.js:63:11
    at ChildProcess.exithandler (child_process.js:641:7)
    at ChildProcess.EventEmitter.emit (events.js:98:17)
    at maybeClose (child_process.js:735:16)
    at Socket.<anonymous> (child_process.js:948:11)
    at Socket.EventEmitter.emit (events.js:95:17)
    at Pipe.close (net.js:466:12)
```

I'm running two nodemon's in the background, starting them one after the other.

I found the cause was that they got the same `Date.now()` value. I guess it depends on the resolution of the clock . I've only seen it a couple of times in hundreds of runs but after the first time I added logging of the filename and found it was the same. Using a random name should fix this.
