### PR TITLE
Add support of --harmony* flags passing to node

### DIFF
--- a/lib/cli/parse.js
+++ b/lib/cli/parse.js
@@ -87,7 +87,7 @@ function parse(argv) {
  * @return {Boolean} false if argument was not a nodemon arg
  */
 function nodemonOption(options, arg, eatNext) {
-  if (arg.indexOf('--debug') === 0 || arg === '--debug-brk' || arg === '--nodejs') {
+  if (arg.indexOf('--debug') === 0 || arg === '--debug-brk' || arg === '--nodejs' || arg.indexOf('--harmony') === 0) {
     if (!options.nodeArgs) { options.nodeArgs = []; }
     options.nodeArgs.push(arg);
   }

--- a/test/cli/parse.test.js
+++ b/test/cli/parse.test.js
@@ -79,6 +79,14 @@ describe('nodemon CLI parser', function () {
     assert(settings.execOptions.exec === 'node');
     assert(settings.nodeArgs[0] === '--debug');
   });
+
+  it('should pass --harmony to node', function () {
+    var settings = parse(asCLI('--harmony test/fixtures/app.js'));
+
+    assert(settings.script === 'test/fixtures/app.js');
+    assert(settings.execOptions.exec === 'node');
+    assert(settings.nodeArgs[0] === '--harmony');
+  });
 });
 
 describe('nodemon argument parser', function () {


### PR DESCRIPTION
I'm using `--harmony` flag to play with Koa.js, and prior to version 1.0.0 (I think that was 0.9.17) it worked just fine with nodemon. Like, everything before file name was considered as node args, and after it as application args, with nodemon args in the middle:
`nodemon --harmony -e js,jade,json index.js --port=3000`

But now, with 1.0.0, nodemon started to pass all arguments (except `--debug*` and `--nodejs`) to the app itself, so `--harmony` doesn't work anymore.

With this PR I'm trying to solve this particular problem with `--harmony`.
Probably, more generic way to support all node args without listing them in `parse.js` would be much better, but I just can't came up with one right now as I'm very new to all this node.js stuff. Sorry. :)
