### PR TITLE
Restore ability to watch multiple arbitrary directories

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -47,8 +47,8 @@ config.load = function (settings, ready) {
     // read directories to monitor
     options.watch.forEach(function (dir) {
       dir = path.resolve(dir);
-      if (existsSync(config.dir)) {
-        config.dirs.push(path.resolve(config.dir));
+      if (existsSync(dir)) {
+        config.dirs.push(dir);
       }
     });
 


### PR DESCRIPTION
Previously the `--watch` CLI flag appeared to have no effect. Certainly not the effect as documented in the README.
