### PR TITLE
Make the ignore flag work on Mac.

### DIFF
--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -38,7 +38,7 @@ bus.on('config:update', function () {
     // let's do a sanity check for the amount of files we'll be watching for...
     var cmds = [];
     config.dirs.forEach(function(dir) {
-      cmds.push('find -L "' + dir + '" -type f | wc');
+      cmds.push('find -L "' + dir + '" -type f ' + ignoredFileTypesForFind(dir) + ' | wc');
     });
 
     exec(cmds.join(';'), function (error, stdout) {
@@ -59,7 +59,7 @@ bus.on('config:update', function () {
       var cmds = [];
 
       config.dirs.forEach(function(dir) {
-        cmds.push('find -L "' + dir + '" -type f -mtime -' + ((Date.now() - config.lastStarted)/1000|0) + 's -print');
+        cmds.push('find -L "' + dir + '" -type f ' + ignoredFileTypesForFind(dir) + ' -mtime -' + ((Date.now() - config.lastStarted)/1000|0) + 's -print');
       });
 
       exec(cmds.join(';'), function (error, stdout) {
@@ -162,6 +162,25 @@ function ignoredFilter(file) {
   } else {
     return true;
   }
+}
+
+function ignoredFileTypesForFind(dir) {
+  // search within dir for ignored files and paths
+  if (!config.options.ignore.length) {
+    return '';
+  }
+  var paths = [];
+  if (dir.charAt(dir.length - 1) != '/') {
+    dir += '/';
+  }
+  config.options.ignore.forEach(function (path) {
+    var pathIsDir = (path.charAt(path.length - 1) == '/');
+    if (pathIsDir) {
+      paths.push('! -ipath "' + dir + path + '*"');
+    }
+    paths.push('! -ipath "' + dir + path + '"');
+  });
+  return ' \\( ' + paths.join(' -and ') + ' \\)';
 }
 
 function filterAndRestart(files) {


### PR DESCRIPTION
I am running node.js on Mac and using nodemon. The "ignore" flag is not working for me, because the nodemon code uses Mac's "find" command to determine which files to watch. In this fork, I have added a commit that will check for the ignored files when running the "find" command.
