### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ nodemon was original written to restart hanging processes such as web servers, b
 
 ## Manual restarting
 
-Whilst nodemon is running, if you need to manually restart your application, instead of stopping and restart nodemon, you can simply type `rs` with a carridge return, and nodemon will restart your process.
+Whilst nodemon is running, if you need to manually restart your application, instead of stopping and restart nodemon, you can simply type `rs` with a carriage return, and nodemon will restart your process.
 
 ## Config files
 
@@ -130,7 +130,7 @@ Now nodemon will restart on any changes to files in the directory (or subdirecto
 
 ## Ignoring files
 
-By default, if nodemon will only restart when a `.js` JavaScript file changes. In some cases you will want to ignore some specific files, directories or file patterns, to prevent nodemon from prematurely restarting your application.
+By default, nodemon will only restart when a `.js` JavaScript file changes. In some cases you will want to ignore some specific files, directories or file patterns, to prevent nodemon from prematurely restarting your application.
 
 This can be done via the command line:
 
@@ -148,7 +148,7 @@ Note that by default, nodemon will ignore the `.git` and `node_modules/**/node_m
 
 ## Delaying restarting
 
-In some situations, you may want to wait until a number of files have changed. The timeout before checking for new file changes is 1 second. If you're uploading a number of files and it's taking some number of seconds, this could cause your app to restart multiple time unnecessarily.
+In some situations, you may want to wait until a number of files have changed. The timeout before checking for new file changes is 1 second. If you're uploading a number of files and it's taking some number of seconds, this could cause your app to restart multiple times unnecessarily.
 
 To add an extra throttle, or delay restarting, use the `--delay` command:
 
@@ -173,7 +173,7 @@ The following example will listen once for the `SIGUSR2` signal (used by nodemon
     process.once('SIGUSR2', function () {
       gracefulShutdown(function () {
         process.kill(process.pid, 'SIGUSR2');
-      })
+      });
     });
 
 Note that the `process.kill` is *only* called once your shutdown jobs are complete. Hat tip to [Benjie Gillam](http://www.benjiegillam.com/2011/08/node-js-clean-restart-and-faster-development-with-nodemon/) for writing this technique up.


### PR DESCRIPTION
There's another under the [Config files section](https://github.com/remy/nodemon/blob/master/README.md#config-files). Relevant passage in bold:

> The above nodemon.json file might be my global config so that I have support for ruby files and processing files, and I can simply run nodemon demo.pde and nodemon will automatically know how to run the script **even though out of the box support for processing scripts.**

I wasn't sure what this was trying to say exactly so I left it alone.
