### PR TITLE
Fixed #334

### DIFF
--- a/lib/monitor/match.js
+++ b/lib/monitor/match.js
@@ -116,7 +116,14 @@ function tryBaseDir(dir) {
       // console.log(error);
     }
   } else {
-    return path.dirname(dir);
+    try {
+      var stat = fs.statSync(dir);
+      // if this path is actually a single file that exists, then just monitor
+      // that, *specifically*.
+      if (stat.isFile() || stat.isDirectory()) {
+        return dir;
+      }
+    } catch (e) {}
   }
 
   return false;

--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -47,6 +47,8 @@ bus.on('config:update', function () {
         total += line.trim().split(/\s+/)[0] * 1;
       });
 
+      utils.log.detail('watching ' + total + ' files');
+
       if (total > 25000) {
         utils.log.fail('watching ' + (total).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',') + ' files - this might cause high cpu usage. To reduce use "--watch".');
       }

--- a/lib/nodemon.js
+++ b/lib/nodemon.js
@@ -222,10 +222,11 @@ if (!config.required) {
     console.error('exception in nodemon killing node');
     console.error(err.stack);
     console.error();
-    console.error('node: ' + process.version);
-    console.error('command: ' + process.argv.join(' '));
-    console.error();
-    console.error('If appropriate, please file an error: http://github.com/remy/nodemon/issues/new\n');
+    console.error('----------------------------------------------------------');
+    console.error('If appropriate, please file an error with the output from:');
+    console.error('$ ' + process.argv.join(' ') + (process.argv.indexOf('--dump') === -1 ? '--dump' : ''));
+    console.error('At http://github.com/remy/nodemon/issues/new');
+    console.error('----------------------------------------------------------\n');
     if (!config.required) {
       process.exit(1);
     }


### PR DESCRIPTION
If a single file was being watched, it would use the tryBaseDir method to work out the directory, but fail as a pattern so it would return the base directory - which is too much. Now we test if that string is a real file or a directory, and if it is, it returns _that_ back out.
