### PR TITLE
Fix never restarting the application if a --watch argument is a file

### DIFF
--- a/lib/monitor/changed-since.js
+++ b/lib/monitor/changed-since.js
@@ -26,6 +26,7 @@ function changedSince(time, dir, callback) {
     todo++;
     fs.readdir(dir, function (err, files) {
       if (err) {
+        done();
         return;
       }
 


### PR DESCRIPTION
In legacy mode, if a --watch argument is an **existing** file, nodemon silently fails to monitor the other files

Repro:

```
nodemon -L --watch ./existing_dir --watch ./existing_file.js  .
```
