### PR TITLE
Find command optimization

### DIFF
--- a/lib/config/checkWatchSupport.js
+++ b/lib/config/checkWatchSupport.js
@@ -42,6 +42,8 @@ function checkWatchSupport(config, callback) {
   // this is because it has a default ulimit of 256 - which is WAY LOW,
   // and without asking the user to `unlimit -n <BIG-ASS-NUMBER>` it'll throw
   // up all over your screen like this: http://d.pr/i/R6B8+
+  // even with higher ulimit -n Mac has another problem: https://github.com/joyent/node/issues/5463
+  // This will be fixed in 0.12, before then we default to find
   config.system.useFind = utils.isMac || !fs.watch;
   if (config.system.useFind) {
     exec('find -L /dev/null -type f -mtime -1s -print', function(error) {

--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -34,7 +34,7 @@ function reset() {
 function showWatchCount() {
   var cmds = [];
   config.dirs.forEach(function(dir) {
-    cmds.push('find -L "' + dir + '" -type f ' + ignoredFileTypesForFind(dir) + ' | wc');
+    cmds.push('find -L "' + dir + '" ' + ignoredFileTypesForFind(dir) + ' \\( -type f -print \\) | wc');
   });
 
   exec(cmds.join(';'), function (error, stdout) {
@@ -64,7 +64,7 @@ bus.on('config:update', function () {
       var cmds = [];
 
       config.dirs.forEach(function(dir) {
-        cmds.push('find -L "' + dir + '" -type f ' + ignoredFileTypesForFind(dir) + ' -mtime -' + ((Date.now() - config.lastStarted)/1000|0) + 's -print');
+        cmds.push('find -L "' + dir + '" ' + ignoredFileTypesForFind(dir) + ' \\( -type f -and -mtime -' + ((Date.now() - config.lastStarted)/1000|0) + 's -print \\)');
       });
 
       exec(cmds.join(';'), function (error, stdout) {
@@ -182,11 +182,11 @@ function ignoredFileTypesForFind(dir) {
   config.options.ignore.forEach(function (path) {
     var pathIsDir = (path.charAt(path.length - 1) == '/');
     if (pathIsDir) {
-      paths.push('! -ipath "' + dir + path + '*"');
+      paths.push(' -ipath "' + dir + path + '*" -prune');
     }
-    paths.push('! -ipath "' + dir + path + '"');
+    paths.push(' -ipath "' + dir + path + '" -prune');
   });
-  return ' \\( ' + paths.join(' -and ') + ' \\)';
+  return ' \\( ' + paths.join(' -or ') + ' \\) -or ';
 }
 
 function filterAndRestart(files) {


### PR DESCRIPTION
This change optimizes the find command by stopping it from recursing into the directories that the user specifies in the --ignore.

Previously find would enter those directories and recursively search them - none of the files from them were ever printed.

In my use case (with a lot of symlinks in node_modules) this speeds up each find call 60 times.
