### PR TITLE
Fix infinite recursion caused by dir symlink

### DIFF
--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -105,7 +105,7 @@ bus.on('config:update', function () {
             files.forEach(function (rawfile) {
               var file = path.join(dir, rawfile);
               if (watched.indexOf(file) === -1) {
-                fs.stat(file, function (err, stat) {
+                fs.lstat(file, function (err, stat) {
                   if (err || !stat) { return; }
 
                   // if we're using fs.watch, then watch directories


### PR DESCRIPTION
`stat.isDirectory()` (https://github.com/remy/nodemon/blob/master/lib/monitor/watch.js#L112) returns true for symlinks pointing to a directory, potentially resulting in an infinite `watch()` recurse.

To reproduce:

```
mkdir test && cd test
touch test.js
ln -s . test
nodemon ./test.js
```

also

```
ln -s . ./node_modules/test
```

node CPU usage % should be very high now.
