### PR TITLE
exit REPL without exiting process

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -16,6 +16,8 @@ Create an nodemon.json file with the setting:
 
 This will leave the STDIN to your application rather than listening for the `rs` command to restart.
 
+`CTRL+C` twice to exit the process, `CTRL+D` or `.exit` to exit the running REPL.
+
 # My script arguments are being taken by nodemon
 
 Use the `--` switch to tell nodemon to ignore all arguments after this point. So to pass `-L` to your script instead of nodemon, use:

--- a/lib/nodemon.js
+++ b/lib/nodemon.js
@@ -113,7 +113,9 @@ function nodemon(settings) {
           }
           ctrlC = true;
         } else if (buffer === '.exit' || chr === 4) {
-          process.exit();
+          // allow the REPL to exit normally without killing the process.
+          console.log('exiting REPL...');
+          buffer = '';
         } else if (ctrlC || chr === 10) {
           ctrlC = false;
           buffer = '';

--- a/lib/nodemon.js
+++ b/lib/nodemon.js
@@ -107,14 +107,18 @@ function nodemon(settings) {
         buffer += data;
         data = data.toString();
         var chr = data.charCodeAt(0);
+        if (chr === 13) {
+          console.log('');
+        }
         if (chr === 3) {
           if (ctrlC) {
             process.exit();
           }
+          utils.log.info('Press ctrl+C again to exit process.');
           ctrlC = true;
         } else if (buffer === '.exit' || chr === 4) {
           // allow the REPL to exit normally without killing the process.
-          console.log('exiting REPL...');
+          utils.log.info('Received exit signal. Use ctrl+C to exit process.');
           buffer = '';
         } else if (ctrlC || chr === 10) {
           ctrlC = false;


### PR DESCRIPTION
I want to embed a REPL and be able to exit the REPL without exiting the process.

Take this code as example:

```
express = require("express");
repl = require("repl");

app = express();

start = function(context) {
  r = repl.start("> ");
  for (k in context) {
    r.context[k] = context[k];
  }
  r.on('exit', function() {
    console.log("about to do some important stuff before exiting the REPL");
  });
};

app.get('/', function(req, res) {
  start({
    req: req,
    res: res
  });
  res.send("OK");
});

server = app.listen(3000, function() {
  console.log('Listening on port %d', server.address().port);
});
```

Without this small change, ctrl+d in the embedded REPL will exit the process completely, without even firing the REPL's exit event. With this PR, ctrl+d will exit the REPL but leave the process alive, whereas two `ctrl+c`s will exit the process as usual.
