### PR TITLE
Do not traverse ignored folders

### DIFF
--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -104,7 +104,7 @@ bus.on('config:update', function () {
 
             files.forEach(function (rawfile) {
               var file = path.join(dir, rawfile);
-              if (watched.indexOf(file) === -1) {
+              if (watched.indexOf(file) === -1 && ignoredFilter(file)) {
                 fs.stat(file, function (err, stat) {
                   if (err || !stat) { return; }
 


### PR DESCRIPTION
Watch should not recursively go in the ignored directories like `node_modules`
