### PR TITLE
Properly detect directories

### DIFF
--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -180,7 +180,7 @@ function ignoredFileTypesForFind(dir) {
     dir += '/';
   }
   config.options.ignore.forEach(function (path) {
-    var pathIsDir = (path.charAt(path.length - 1) == '/');
+    var pathIsDir = (fs.existsSync(dir + path) && fs.statSync(dir + path).isDirectory()) || (path.charAt(path.length - 1) == '/');
     if (pathIsDir) {
       paths.push('! -ipath "' + dir + path + '*"');
     }


### PR DESCRIPTION
Fixes #366, obsoletes  #371. Filesystem information used in addition to trailing slash.
