### PR TITLE
Update watch.js

### DIFF
--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -189,8 +189,12 @@ function ignoredFileTypesForFind(dir) {
   return ' \\( ' + paths.join(' -and ') + ' \\)';
 }
 
+var _needPatchDriveLetter = process.platform == 'win32';
 function filterAndRestart(files) {
   if (files.length) {
+    if (_needPatchDriveLetter)
+      files = files.map (function (f) { return f[0].toUpperCase() + f.slice(1); });
+    
     var cwd = process.cwd();
     utils.log.detail('files triggering change check: ' + files.map(function (file) {
       return path.relative(cwd, file);


### PR DESCRIPTION
This fixes #399, fixes #392, fixes #376 by make the drive letter upper-case.

This is caused by `path.join`, the returned path has a lower-cased drive letter:

``` text
> path.join('C:\\', 'Test')
'c:\\Test'
```

Later check path against rules using minimatch, it failed as `options.nocase` is `false` by default.
