### PR TITLE
Check stdin option when wrapping

### DIFF
--- a/lib/nodemon.js
+++ b/lib/nodemon.js
@@ -94,7 +94,7 @@ function nodemon(settings) {
           bus.emit('restart');
         }
       });
-    } else {
+    } else if (config.options.stdin) {
       // if 'restartable' is disabled (via a nodemon.json)
       // then it's possible we're being used with a REPL
       // so let's make sure we don't eat the key presses


### PR DESCRIPTION
This PR makes it possible to start and stop nodemon apps using tools such as `gulp` or `grunt`.

``` js
var nodemon = require('nodemon');

nodemon({
  script: 'index.js',
  ext: 'js',
  restartable: false,
  stdin: false
});

nodemon.on('start', function () {
  console.log('Start');

  setTimeout(function() {
    nodemon.emit('quit');
  }, 1000);
});
```
