### PR TITLE
Accept an Array (as well as string) for options.exec

### DIFF
--- a/lib/config/exec.js
+++ b/lib/config/exec.js
@@ -37,26 +37,34 @@ function exec(nodemonOptions, execMap) {
     execDefined = true;
   }
 
+  options.execArgs = [];
+
   if (options.exec === undefined) {
     options.exec = 'node';
   } else {
+    if (Array.isArray(options.exec)) {
+      options.execArgs = options.exec;
+      options.exec = options.execArgs.shift();
+    } else if (options.exec.indexOf(' ') !== -1) {
+      var execOptions = options.exec.split(' ');
+      options.exec = execOptions.splice(0, 1)[0];
+      options.execArgs = execOptions;
+    }
+
     // allow variable substitution for {{filename}} and {{pwd}}
-    options.exec = (options.exec || '').replace(/\{\{(filename|pwd)\}\}/, function (all, m) {
-      if (m === 'filename') {
-        return script || '';
-      } else if (m === 'pwd') {
-        return process.cwd() || '';
-      }
-      return all;
-    });
-  }
+    var substitute = function(str) {
+      return str.replace(/\{\{(filename|pwd)\}\}/, function (all, m) {
+        if (m === 'filename') {
+          return script || '';
+        } else if (m === 'pwd') {
+          return process.cwd() || '';
+        }
+        return all;
+      });
+    };
 
-  options.execArgs = [];
-
-  if (options.exec.indexOf(' ') !== -1) {
-    var execOptions = options.exec.split(' ');
-    options.exec = execOptions.splice(0, 1)[0];
-    options.execArgs = execOptions;
+    options.exec = substitute(options.exec);
+    options.execArgs = options.execArgs.map(substitute);
   }
 
   if (options.exec === 'node' && options.nodeArgs && options.nodeArgs.length) {

--- a/test/cli/exec.test.js
+++ b/test/cli/exec.test.js
@@ -44,6 +44,13 @@ describe('nodemon exec', function () {
     assert(cmd.executable + ' ' + cmd.args.join(' ') === 'node app.js.tmp --somethingElse', 'filename is interpolated');
   });
 
+  it('should not split on spaces in {{filename}}', function () {
+    var options = exec({ script: 'my app.js', exec: 'node {{filename}}.tmp --somethingElse' });
+    var cmd = command({ execOptions: options });
+
+    assert(cmd.args[0] === 'my app.js.tmp', cmd.args[0]);
+  });
+
   it('should support extension maps', function () {
     var options = exec({ script: 'template.jade' }, { 'jade': 'jade {{filename}} --out /tmp' });
     assert(options.exec === 'jade', 'correct exec is used');
@@ -82,6 +89,14 @@ describe('nodemon exec', function () {
     assert(options.exec === 'python');
     assert(options.execArgs.indexOf('--debug') !== -1);
     assert(options.ext.indexOf('py') !== -1);
+  });
+
+  it('should support an array of exec arguments', function() {
+    var options = exec({script: 'app.js', exec: ['/path to node', '-v']});
+
+    assert(options.exec === '/path to node', options.exec);
+    assert(options.execArgs.length === 1, options.execArgs.length);
+    assert(options.execArgs[0] === '-v', options.execArgs[0]);
   });
 
 });


### PR DESCRIPTION
When an array is given, don't do any splitting on spaces.

This is a simpler alternative to #418 which doesn't affect the CLI interface, just the API. Although it does fix a bug in the CLI's `{{filename}}` and `{{pwd}}` expansion as a side effect, which I've added a test for too.
