### PR TITLE
adds support for commented JSON configuration

### DIFF
--- a/lib/config/load.js
+++ b/lib/config/load.js
@@ -1,6 +1,7 @@
 'use strict';
 var fs = require('fs'),
     path = require('path'),
+    cjson = require('cjson'),
     exists = fs.exists || path.exists,
     utils = require('../utils'),
     rules = require('../rules'),
@@ -158,7 +159,7 @@ function loadFile(options, config, dir, ready) {
     var settings = {};
 
     try {
-      settings = JSON.parse(data);
+      settings = cjson.parse(data);
       config.loaded.push(filename);
     } catch (e) {
       console.error(e);

--- a/lib/rules/parse.js
+++ b/lib/rules/parse.js
@@ -1,5 +1,6 @@
 'use strict';
 var fs = require('fs');
+var cjson = require('cjson');
 
 /**
  * Parse the nodemon config file, supporting both old style
@@ -22,7 +23,7 @@ function parse(filename, callback) {
 
     var json = null;
     try {
-      json = JSON.parse(content);
+      json = cjson.parse(content);
     } catch (e) {}
 
     if (json !== null) {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "touch": "~0.0.3"
   },
   "dependencies": {
+    "cjson": "~0.3.0",
     "minimatch": "~0.3.0",
     "ps-tree": "~0.0.3",
     "update-notifier": "~0.1.8"

--- a/test/monitor/match.test.js
+++ b/test/monitor/match.test.js
@@ -5,6 +5,7 @@ var assert = require('assert'),
     config = require('../../lib/config'),
     path = require('path'),
     fs = require('fs'),
+    cjson = require('cjson'),
     nodemonUtils = require('../../lib/utils'),
     defaults = require('../../lib/config/defaults'),
     utils = require('../utils'),
@@ -197,7 +198,7 @@ describe('validating files that cause restart', function () {
     var dir = cwd + '/test/fixtures/configs';
     process.chdir(dir);
     var filename = './watch-relative.json';
-    var config = JSON.parse(fs.readFileSync(filename));
+    var config = cjson.parse(fs.readFileSync(filename));
     var settings = merge(config, defaults);
     var script = path.resolve('../../../lib/__init__.py');
 
@@ -211,7 +212,7 @@ describe('validating files that cause restart', function () {
 
   it('should allow *.js to match at the top level', function () {
     var filename = path.join('test', 'fixtures', 'configs', 'top-level.json');
-    var config = JSON.parse(fs.readFileSync(filename));
+    var config = cjson.parse(fs.readFileSync(filename));
     var settings = merge(config, defaults);
     var script = path.resolve('app.js');
 
@@ -223,7 +224,7 @@ describe('validating files that cause restart', function () {
 
   it('should allow for simple star rule: public/*', function () {
     var filename = path.join('test', 'fixtures', 'configs', 'public-star.json');
-    var config = JSON.parse(fs.readFileSync(filename));
+    var config = cjson.parse(fs.readFileSync(filename));
     var settings = merge(config, defaults);
     var script = 'public/js/chrome.save.js';
 
@@ -238,7 +239,7 @@ describe('validating files that cause restart', function () {
     var dir = cwd + '/test/fixtures/configs';
     process.chdir(dir);
     var filename = './watch-relative-filter.json';
-    var config = JSON.parse(fs.readFileSync(filename));
+    var config = cjson.parse(fs.readFileSync(filename));
     var settings = merge(config, defaults);
     var script = path.resolve('../jsbin/scripts.json');
 


### PR DESCRIPTION
Our team likes to annotate JS(ON)-based configuration files and adding extra information to settings so "the next guy" knows why certain settings were made.

When possible, we use JS-based config files which support comments natively. In case we have to use JSON, we parse it with `cjson` so as to not break `JSON.parse` with inline-comments.

With this changeset, I added support for parsing commented JSON files (by means of `cjson`). I have also updated the tests.

tl;dr: added support for comments in nodemon.json