### PR TITLE
updated help text grammar

### DIFF
--- a/doc/cli/config.txt
+++ b/doc/cli/config.txt
@@ -31,8 +31,8 @@
       "exec": "processing --sketch={{pwd}} --run"
     }
 
-  The global config file is useful for setting up default default executables
-  instead of needed them in your local config:
+  The global config file is useful for setting up default executables
+  instead of repeating the same option in each of your local configs:
 
     {
       "verbose": true,


### PR DESCRIPTION
"default" was repeated, "needed" didn't make sense
