### PR TITLE
Fixed exec parser

### DIFF
--- a/lib/config/command.js
+++ b/lib/config/command.js
@@ -2,13 +2,14 @@
 
 module.exports = command;
 
-function command(options) {
-  var executable = options.execOptions.exec,
+function command(settings) {
+  var options = settings.execOptions;
+  var executable = options.exec,
       args = [];
 
   // after "executable" go the exec args (like --debug, etc)
-  if (options.execOptions.execArgs) {
-    [].push.apply(args, options.execOptions.execArgs);
+  if (options.execArgs) {
+    [].push.apply(args, options.execArgs);
   }
 
   // then goes the user's script arguments
@@ -18,7 +19,7 @@ function command(options) {
 
   // after the "executable" goes the user's script
   if (options.script) {
-    args.splice((options.scriptPosition || 0) + options.execOptions.execArgs.length, 0, options.script);
+    args.splice((options.scriptPosition || 0) + options.execArgs.length, 0, options.script);
   }
 
   return {

--- a/lib/config/exec.js
+++ b/lib/config/exec.js
@@ -173,9 +173,13 @@ function exec(nodemonOptions, execMap) {
   } else {
     // allow variable substitution for {{filename}} and {{pwd}}
     var substitution = replace.bind(null, { filename: script, pwd: process.cwd() });
-
     options.exec = substitution(options.exec);
-    options.execArgs = options.execArgs.map(substitution);
+
+    var newExecArgs = options.execArgs.map(substitution);
+    if (newExecArgs.join('') !== options.execArgs.join('')) {
+      options.execArgs = newExecArgs;
+      delete options.script;
+    }
   }
 
 

--- a/lib/config/exec.js
+++ b/lib/config/exec.js
@@ -3,6 +3,7 @@ var path = require('path'),
     utils = require('../utils');
 
 module.exports = exec;
+module.exports.parseExecutable = parseExecutable;
 
 function parseExecutable(str) {
   var length = str.length;
@@ -11,36 +12,51 @@ function parseExecutable(str) {
   var exec = null;
   var execArgs = [];
   var token = '';
+  var inspace = false;
+  var escaped = false;
+  var unescapeNextTime = false;
   var open = false;
   var c = null;
 
   for (; i < length; i++) {
     c = str[i];
 
-    switch (c) {
-      case '"':
-      case "'":
-        open = !open;
-        break;
-      case '\\':
-        // skip
-        i+=1;
-        token += str[i];
-        break;
-      case ' ':
-        if (!open) {
-          if (exec === null) {
-            exec = token;
-          } else {
-            execArgs.push(token);
-          }
-
-          token = '';
-          break;
-        }
-      default:
-        token += c;
+    if (unescapeNextTime) {
+      escaped = false;
     }
+
+    unescapeNextTime = escaped;
+
+    if (c === '\\') {
+      escaped = true;
+      // peek next character
+      if (str[i+1] === ' ') { // space we skip
+        inspace = true;
+      }
+    }
+
+    if (!escaped && (c === '"' || c === "'")) {
+      open = !open;
+      // continue;
+    }
+
+    if (c === ' ') {
+      if (!open && inspace === false) {
+        if (exec === null) {
+          exec = token;
+        } else {
+          execArgs.push(token);
+        }
+
+        // reset the token now
+        token = '';
+        continue;
+      } else if (inspace) {
+        inspace = false;
+      }
+    }
+
+    token += c;
   }
 
   // deal with the left overs

--- a/lib/config/exec.js
+++ b/lib/config/exec.js
@@ -44,6 +44,9 @@ function parseExecutable(str) {
       if (!open && inspace === false) {
         if (exec === null) {
           exec = token;
+          execArgs.push(str.slice(i + 1));
+          token = '';
+          break;
         } else {
           execArgs.push(token);
         }

--- a/lib/config/load.js
+++ b/lib/config/load.js
@@ -37,21 +37,33 @@ function load(settings, options, config, callback) {
         script: options.script,
         exec: options.exec,
         args: options.args,
+        scriptPosition: options.scriptPosition,
         nodeArgs: options.nodeArgs,
         ext: options.ext,
         env: options.env
       }, options.execMap);
 
+      // clean up values that we don't need at the top level
+      delete options.scriptPosition;
+      delete options.script;
+      delete options.args;
+      delete options.ext;
+
+      /*
       // if the script was discovered via package.main or package.start, it
       // would have happened in the `exec` function above, except `options.script`
       // doesn't get updated, when `options.execOptions.script` does actually
-      // hold the right value now, so we copy it across.
+      // hold the right value now, so we copy it across along with the
+      // scriptPosition as this is used in command.js to correctly construct
+      // the executable command
       if (!options.script && options.execOptions.script) {
         options.script = options.execOptions.script;
+        // options.scriptPosition = options.execOptions.scriptPosition;
       }
+      */
 
       // copy the extension across to a user readable format
-      options.ext = options.execOptions.ext.replace(/[\*\.\$]/g, '').split('|').join(' ');
+      // options.ext = options.execOptions.ext.replace(/[\*\.\$]/g, '').split('|').join(' ');
 
       if (options.quiet) {
         utils.quiet();

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -40,21 +40,34 @@ function run(options) {
   }
 
   var args = '';
-  [cmd.executable].concat(cmd.args).forEach(function (arg) {
-    if (arg.match(/[ '"]/)) {
-      arg = '"' + arg.replace(/"/g, '\\"') + '"';
-    }
-    args += ' ' + arg;
-  });
+
+  console.log(cmd);
+
+  args = [cmd.executable].concat(cmd.args).join(' ').trim();
+  if (args.match(/[ '"]/)) {
+    // if there's any quotes in the command, then it'll wrap the entire command
+    // in quotes (escaping any inner quotes), then pass the whole thing to sh -c
+    args = '"' + args.replace(/"/g, '\\"') + '"';
+  }
+
+  var spawnArgs = [];
+
+  if (args.match(/\|&></)) {
+    spawnArgs = [sh, [shFlag, args]];
+  } else {
+    spawnArgs = [cmd.executable, cmd.args];
+  }
+
+  console.log('SPAWN', JSON.stringify(spawnArgs));
 
   if (nodeMajor >= 8) {
-    child = spawn(sh, [shFlag, args], {
+    spawnArgs.push({
       env: utils.merge(options.execOptions.env, process.env),
       stdio: stdio
     });
-  } else {
-    child = spawn(sh, args);
   }
+
+  child = spawn.apply(null, spawnArgs);
 
   if (config.required) {
     var emit = {

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -39,26 +39,8 @@ function run(options) {
     shFlag = '/c';
   }
 
-  var args = '';
-
-  console.log(cmd);
-
-  args = [cmd.executable].concat(cmd.args).join(' ').trim();
-  if (args.match(/[ '"]/)) {
-    // if there's any quotes in the command, then it'll wrap the entire command
-    // in quotes (escaping any inner quotes), then pass the whole thing to sh -c
-    args = '"' + args.replace(/"/g, '\\"') + '"';
-  }
-
-  var spawnArgs = [];
-
-  if (args.match(/\|&></)) {
-    spawnArgs = [sh, [shFlag, args]];
-  } else {
-    spawnArgs = [cmd.executable, cmd.args];
-  }
-
-  console.log('SPAWN', JSON.stringify(spawnArgs));
+  var args = [cmd.executable].concat(cmd.args).join(' ').trim();
+  var spawnArgs = [sh, [shFlag, args]];
 
   if (nodeMajor >= 8) {
     spawnArgs.push({

--- a/lib/nodemon.js
+++ b/lib/nodemon.js
@@ -62,7 +62,7 @@ function nodemon(settings) {
   }
 
   config.load(settings, function (config) {
-    if (!config.options.dump && !config.options.script && config.options.execOptions.exec === 'node') {
+    if (!config.options.dump && !config.options.execOptions.script && config.options.execOptions.exec === 'node') {
       if (!config.required) {
         console.log(help('usage'));
         process.exit();

--- a/test/cli/exec.test.js
+++ b/test/cli/exec.test.js
@@ -40,8 +40,7 @@ describe('nodemon exec', function () {
   it('should replace {{filename}}', function () {
     var options = exec({ script: 'app.js', exec: 'node {{filename}}.tmp --somethingElse' });
     var cmd = command({ execOptions: options });
-
-    assert(cmd.executable + ' ' + cmd.args.join(' ') === 'node app.js.tmp --somethingElse', 'filename is interpolated');
+    assert(cmd.executable + ' ' + cmd.args.join(' ') === 'node app.js.tmp --somethingElse', 'filename is interpolated: ' + cmd.executable + ' ' + cmd.args.join(' '));
   });
 
   it('should not split on spaces in {{filename}}', function () {

--- a/test/cli/exec.test.js
+++ b/test/cli/exec.test.js
@@ -48,13 +48,13 @@ describe('nodemon exec', function () {
     var options = exec({ script: 'my app.js', exec: 'node {{filename}}.tmp --somethingElse' });
     var cmd = command({ execOptions: options });
 
-    assert(cmd.args[0] === 'my app.js.tmp', cmd.args[0]);
+    assert(cmd.args[0] === 'my app.js.tmp --somethingElse', cmd.args[0]);
   });
 
   it('should support extension maps', function () {
     var options = exec({ script: 'template.jade' }, { 'jade': 'jade {{filename}} --out /tmp' });
     assert(options.exec === 'jade', 'exec used, should be "jade": ' + options.exec);
-    assert(options.execArgs[0] === 'template.jade', 'filename interpolated');
+    assert(options.execArgs[0] === 'template.jade --out /tmp', 'filename interpolated');
   });
 
   it('should support input from argv#parse', function () {

--- a/test/cli/parse.test.js
+++ b/test/cli/parse.test.js
@@ -112,7 +112,7 @@ describe('nodemon CLI parser', function () {
 
     process.chdir(pwd);
 
-    assert(options.exec === 'app with spaces.js', 'exec is: ' + options.exec);
+    assert(options.exec === '"app with spaces.js"', 'exec is: ' + options.exec);
     assert(options.execArgs[0] === 'foo', 'execArgs is: ' + options.execArgs[0]);
   });
 

--- a/test/config/load.test.js
+++ b/test/config/load.test.js
@@ -15,12 +15,6 @@ function asCLI(cmd) {
   return ('node nodemon ' + (cmd|| '')).trim();
 }
 
-function parse(cmd) {
-  var parsed = cli.parse(cmd);
-  parsed.execOptions = exec(parsed);
-  return parsed;
-}
-
 function commandToString(command) {
   return command.executable + (command.args.length ? ' ' + command.args.join(' ') : '');
 }
@@ -149,6 +143,20 @@ describe('config load', function () {
       assert.deepEqual(config.exec, 'foo', 'exec is "foo": ' + config.exec);
       done();
     });
+  });
+
+  it('should put the script at the end if found in package.scripts.start', function (done) {
+    process.chdir(path.resolve(pwd, 'test/fixtures/packages/start')); // allows us to load text/fixtures/package.json
+    var settings = cli.parse(asCLI('--harmony'));
+    var config = {};
+    var options = {};
+
+    load(settings, options, config, function (config) {
+      var cmd = commandToString(command(config));
+      assert(cmd === 'node --harmony app.js', 'command is ' + cmd);
+      done();
+    });
+
   });
 
   it('should support "ext" with "execMap"', function (done) {

--- a/test/config/parse-exec.test.js
+++ b/test/config/parse-exec.test.js
@@ -1,0 +1,66 @@
+'use strict';
+/*global describe:true, it: true, after: true */
+var parseExecutable = require('../../lib/config/exec').parseExecutable,
+    assert = require('assert');
+
+describe('exec.parseExecutable', function () {
+  it('should parse simple commands', function () {
+    var cmd = 'run.js';
+    var result = parseExecutable(cmd);
+    assert(result.exec === cmd, result.exec);
+  });
+
+  it('should parse simple commands with space separated arguments', function () {
+    var cmd = 'run.js --arg1 --arg2';
+    var result = parseExecutable(cmd);
+    assert(result.exec === 'run.js', result.exec);
+    assert(result.execArgs.length === 2, 'args.length ' + result.execArgs.length);
+    assert(result.execArgs[0] === '--arg1', result.execArgs[0]);
+    assert(result.execArgs[1] === '--arg2', result.execArgs[1]);
+  });
+
+  it('should leave escaped characters alone', function () {
+    var cmd = 'test/fixtures/some \\file'
+    var result = parseExecutable(cmd);
+    assert(result.exec === 'test/fixtures/some', 'exec: ' + result.exec);
+    assert(result.execArgs[0] === '\\file', 'arg: ' + result.execArgs[0]);
+  });
+
+  it('should maintain space separated commands', function () {
+    var cmd = 'test/fixtures/some\\ \\file';
+    var result = parseExecutable(cmd);
+    assert(result.exec === cmd, 'exec: ' + result.exec);
+    assert(result.execArgs.length === 0, 'arg: ' + JSON.stringify(result.execArgs));
+  });
+
+  it('should handle test/fixtures/some\\\"file', function () {
+    var cmd = 'test/fixtures/some\\\"file';
+    var result = parseExecutable(cmd);
+    assert(result.exec === cmd, 'exec: ' + result.exec);
+    assert(result.execArgs.length === 0, 'arg: ' + JSON.stringify(result.execArgs));
+  });
+
+  it('should handle some\\\"file\\" "and some"', function () {
+    var cmd = 'some\\\"file\\" "and some"';
+    var result = parseExecutable(cmd);
+    assert(result.exec === 'some\\\"file\\"', 'exec: ' + result.exec);
+  });
+
+  it('should handle "test/fixtures/app with spaces.js" foo', function () {
+    var cmd = '"test/fixtures/app with spaces.js" foo';
+    var result = parseExecutable(cmd);
+    assert(result.exec === '"test/fixtures/app with spaces.js"', 'exec: ' + result.exec);
+  });
+
+  // it('should handle echo -e "line1\\nline2"', function () {
+  //   var cmd = '"echo -e \"line1\\nline2\""';
+  //   var result = parseExecutable(cmd);
+  //   assert(result.exec === cmd, 'exec: ' + result.exec);
+  // });
+
+  it('should handle simple spaces: test/fixtures/app\\ with\\ spaces.js', function () {
+    var cmd = 'test/fixtures/app\\ with\\ spaces.js';
+    var result = parseExecutable(cmd);
+    assert(result.exec === cmd, 'exec: ' + result.exec);
+  });
+});

--- a/test/config/parse-exec.test.js
+++ b/test/config/parse-exec.test.js
@@ -14,9 +14,8 @@ describe('exec.parseExecutable', function () {
     var cmd = 'run.js --arg1 --arg2';
     var result = parseExecutable(cmd);
     assert(result.exec === 'run.js', result.exec);
-    assert(result.execArgs.length === 2, 'args.length ' + result.execArgs.length);
-    assert(result.execArgs[0] === '--arg1', result.execArgs[0]);
-    assert(result.execArgs[1] === '--arg2', result.execArgs[1]);
+    assert(result.execArgs.length === 1, 'args.length ' + result.execArgs.length);
+    assert(result.execArgs[0] === '--arg1 --arg2', result.execArgs[0]);
   });
 
   it('should leave escaped characters alone', function () {

--- a/test/events/complete.test.js
+++ b/test/events/complete.test.js
@@ -25,6 +25,10 @@ describe('events should follow normal flow on user triggered change', function (
     }).emit('quit');
   });
 
+  before(function (done) {
+    nodemon.reset(done);
+  });
+
   after(function (done) {
     nodemon.once('exit', function () {
       nodemon.reset(done);

--- a/test/fork/config.test.js
+++ b/test/fork/config.test.js
@@ -34,7 +34,7 @@ describe('nodemon full config test', function () {
         if (match(event.data.message, 'starting `')) {
           event.data.message.replace(/`(.*)`/, function (all, m) {
             assert(m === 'node --harmony app.js', 'Arguments in the correct order: ' + m);
-            p.send('quit');
+            // p.send('quit');
             cleanup(p, done);
           });
         }

--- a/test/lib/require.test.js
+++ b/test/lib/require.test.js
@@ -61,7 +61,7 @@ describe('require-able', function () {
     var found = false;
     utils.port++;
     nodemon({
-      exec: [path.resolve(__dirname, '..', 'fixtures', 'app with spaces.js'), 'foo'],
+      exec: [path.resolve(__dirname, '..', 'fixtures', 'app\\ with\\ spaces.js'), 'foo'],
       verbose: true,
       stdout: false,
       env: { PORT: utils.port }

--- a/test/monitor/changed-since.test.js
+++ b/test/monitor/changed-since.test.js
@@ -19,7 +19,7 @@ describe('change monitor', function () {
     setTimeout(function () {
       start = Date.now();
       changedSince(start, dir, function (files) {
-        assert(files.length === 0, 'zero files');
+        assert(files.length === 0, 'expected zero files, ' + JSON.stringify(files));
         done();
       });
     }, 2000);

--- a/test/monitor/match.test.js
+++ b/test/monitor/match.test.js
@@ -315,11 +315,17 @@ describe('match rule parser', function () {
   });
 
   it('should support "--watch .."', function () {
+    // make sure we're in a deep enough directory
+    var cwd = process.cwd();
+    process.chdir('./test/fixtures/');
+    var pwd = process.cwd();
     var config = { watch: '..' };
     var settings = merge(config, defaults);
     var script = pwd + 'index.js';
 
     settings.monitor = match.rulesToMonitor(settings.watch, [], { dirs: [] });
+
+    process.chdir(cwd);
 
     assert(settings.monitor[0] === path.resolve(pwd, '..') + '/**/*', 'path resolved: ' + settings.monitor[0]);
     var matched = match([script], settings.monitor, 'js');


### PR DESCRIPTION
- [x] ready for merge

It was losing quotes around arguments, and in fact only needs to capture the first element in the string as the exec, and the rest could be left as is (if I keep the `sh` method of execution).

Fixes #448