### PR TITLE
Fixed #454

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -12,7 +12,15 @@ var utils = require('../utils'),
     noop = function() {},
     restart = null,
     psTree = require('ps-tree'),
-    nodeMajor = parseInt((process.versions.node.split('.') || [null,null])[1] || 0, 10);
+    nodeMajor = parseInt((process.versions.node.split('.') || [null,null])[1] || 0, 10),
+    hasPS = true;
+
+// discover if the OS has `ps`, and therefore can use psTree
+exec('ps', function(error) {
+  if (error) {
+    hasPS = false;
+  }
+});
 
 function run(options) {
   var cmd = config.command.raw;
@@ -200,17 +208,23 @@ function kill(child, signal, callback) {
     exec('taskkill /pid '+ child.pid + ' /T /F');
     callback();
   } else {
-    // we use psTree to kill the full subtree of nodemon, because when spawning
-    // processes like `coffee` under the `--debug` flag, it'll spawn it's own
-    // child, and that can't be killed by nodemon, so psTree gives us an array
-    // of PIDs that have spawned under nodemon, and we send each the SIGUSR2
-    // signal, which fixes #335
-
-    psTree(child.pid, function (err, children) {
-      spawn('kill', ['-s', signal, child.pid].concat(children.map(function (p) {
-        return p.PID;
-      }))).on('close', callback);
-    });
+    if (hasPS) {
+      // we use psTree to kill the full subtree of nodemon, because when spawning
+      // processes like `coffee` under the `--debug` flag, it'll spawn it's own
+      // child, and that can't be killed by nodemon, so psTree gives us an array
+      // of PIDs that have spawned under nodemon, and we send each the SIGUSR2
+      // signal, which fixes #335
+      psTree(child.pid, function (err, children) {
+        spawn('kill', ['-s', signal, child.pid].concat(children.map(function (p) {
+          return p.PID;
+        }))).on('close', callback);
+      });
+    } else {
+      exec('kill -s ' + signal + ' ' + child.pid, function (error) {
+        // ignore if the process has been killed already
+        callback();
+      });
+    }
   }
 }
 


### PR DESCRIPTION
Detect if `ps` is available, and if not, just try to kill the parent