### PR TITLE
Fix/double escape

### DIFF
--- a/lib/config/exec.js
+++ b/lib/config/exec.js
@@ -69,10 +69,12 @@ function parseExecutable(str) {
     execArgs.push(token);
   }
 
-  return {
+  var result = {
     exec: exec,
     execArgs: execArgs,
   };
+
+  return result;
 }
 
 /**

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -47,6 +47,13 @@ function run(options) {
     shFlag = '/c';
   }
 
+  cmd.args = cmd.args.map(function (arg) {
+    if (arg.indexOf(' ') !== -1) {
+      arg = '"' + arg.replace(/"/g, '\\"') + '"';
+    }
+    return arg;
+  });
+
   var args = [cmd.executable].concat(cmd.args).join(' ').trim();
   var spawnArgs = [sh, [shFlag, args]];
 
@@ -96,6 +103,12 @@ function run(options) {
   });
 
   child.on('exit', function (code, signal) {
+    if (code === 2) {
+      // something wrong with parsed command
+      utils.log.error('failed to start process, possible issue with exec arguments');
+      process.exit();
+    }
+
     // In case we killed the app ourselves, set the signal thusly
     if (killedAfterChange) {
       killedAfterChange = false;

--- a/test/fixtures/some file
+++ b/test/fixtures/some file
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log(process.env.USER || 'OK');

--- a/test/fixtures/some"file
+++ b/test/fixtures/some"file
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log(process.env.USER || 'OK');

--- a/test/fork/change-detect.test.js
+++ b/test/fork/change-detect.test.js
@@ -39,7 +39,7 @@ describe('nodemon fork monitor', function () {
         if (startWatch && match(data, 'changes after filters')) {
           var changes = colour.strip(data.trim()).slice(-5).split('/');
           var restartedOn = changes.pop();
-          assert(restartedOn === '1', 'nodemon restarted on 1 file: ' + restartedOn);
+          assert(restartedOn === '1', 'nodemon restarted on 1 file: ' + restartedOn + ' / ' + data.toString();
         }
       },
       error: function (data) {

--- a/test/fork/change-detect.test.js
+++ b/test/fork/change-detect.test.js
@@ -39,7 +39,7 @@ describe('nodemon fork monitor', function () {
         if (startWatch && match(data, 'changes after filters')) {
           var changes = colour.strip(data.trim()).slice(-5).split('/');
           var restartedOn = changes.pop();
-          assert(restartedOn === '1', 'nodemon restarted on 1 file: ' + restartedOn + ' / ' + data.toString();
+          assert(restartedOn === '1', 'nodemon restarted on 1 file: ' + restartedOn + ' / ' + data.toString());
         }
       },
       error: function (data) {


### PR DESCRIPTION
We do infact need to wrap `sh` arguments with quotes if it contains a space. This does *not* affect escaping on the cli for passing exec args etc.