### PR TITLE
Required nodemon should prioritise options over discovered script

### DIFF
--- a/lib/config/exec.js
+++ b/lib/config/exec.js
@@ -128,7 +128,7 @@ function exec(nodemonOptions, execMap) {
   // this logic used to sit in the cli/parse, but actually the cli should be parsed
   // first, then the user options (via nodemon.json) then finally default down to
   // pot shots at the directory via package.json
-  if (!nodemonOptions.exec) {
+  if (!nodemonOptions.exec && !nodemonOptions.script) {
     var found = execFromPackage();
     if (found !== null) {
       if (found.exec) {

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -96,6 +96,7 @@ function run(options) {
   utils.log.detail('child pid: ' + child.pid);
 
   child.on('error', function (error) {
+    bus.emit('error', error);
     if (error.code === 'ENOENT') {
       utils.log.error('unable to run executable: "' + cmd.executable + '"');
       process.exit(1);
@@ -106,9 +107,16 @@ function run(options) {
   });
 
   child.on('exit', function (code, signal) {
+    if (code === 127) {
+      utils.log.error('failed to start process, "' + cmd.executable + '" exec not found');
+      bus.emit('error', code);
+      process.exit();
+    }
+
     if (code === 2) {
       // something wrong with parsed command
       utils.log.error('failed to start process, possible issue with exec arguments');
+      bus.emit('error', code);
       process.exit();
     }
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "coverage": "istanbul cover _mocha -- --timeout 30000 --ui bdd --reporter list test/**/*.test.js",
     ":test": "node_modules/.bin/mocha --timeout 30000 --ui bdd test/**/*.test.js",
-    "test": "for FILE in `ls test | egrep -v 'fixtures|mocha.opts|utils.js'`; do echo test/$FILE; ./node_modules/.bin/mocha --timeout 30000 test/$FILE; if [ $? -ne 0 ]; then exit 1; fi; sleep 1; done",
+    "test": "for FILE in test/**/*.test.js; do echo $FILE; ./node_modules/.bin/mocha --timeout 30000 $FILE; if [ $? -ne 0 ]; then exit 1; fi; sleep 1; done",
     "web": "node web"
   },
   "devDependencies": {

--- a/test/fixtures/packages/start-ignored/package.json
+++ b/test/fixtures/packages/start-ignored/package.json
@@ -1,0 +1,1 @@
+{ "scripts": { "start": "foo" } }

--- a/test/lib/require.test.js
+++ b/test/lib/require.test.js
@@ -32,9 +32,6 @@ describe('require-able', function () {
       script: envjs,
       env: { USER: 'nodemon' },
       stdout: false,
-      verbose: false,
-    // }).on('log', function (event) {
-      // console.log(event.colour);
     }).on('stdout', function (data) {
       var out = data.toString().trim();
       assert(out === 'nodemon', 'expected output: ' + out);

--- a/test/lib/require.test.js
+++ b/test/lib/require.test.js
@@ -5,7 +5,8 @@ var nodemon = require('../../lib/'),
     path = require('path'),
     touch = require('touch'),
     utils = require('../utils'),
-    appjs = path.resolve(__dirname, '..', 'fixtures', 'app.js');
+    appjs = path.resolve(__dirname, '..', 'fixtures', 'app.js'),
+    envjs = path.resolve(__dirname, '..', 'fixtures', 'env.js');
 
 describe('require-able', function () {
   var pwd = process.cwd(),
@@ -24,6 +25,25 @@ describe('require-able', function () {
     nodemon.reset(done);
   });
 
+  it('should prioritise options over package.start', function (done) {
+    process.chdir(path.resolve('fixtures/packages/start-ignored'));
+
+    nodemon({
+      script: envjs,
+      env: { USER: 'nodemon' },
+      stdout: false,
+      verbose: false,
+    // }).on('log', function (event) {
+      // console.log(event.colour);
+    }).on('stdout', function (data) {
+      var out = data.toString().trim();
+      assert(out === 'nodemon', 'expected output: ' + out);
+      done();
+    }).on('error', function (e) {
+      assert(false, 'script did not run: ' + e);
+      done();
+    });
+  });
 
   it('should know nodemon has been required', function () {
     assert(nodemon.config.required, 'nodemon has required property');


### PR DESCRIPTION
Currently if you require nodemon, and pass it an object with `script` it'll try to load `package.start` *first*. This is wrong.

Tests based on this [comment](https://github.com/JacksonGariety/gulp-nodemon/issues/49#issuecomment-70619759).

Ref https://github.com/JacksonGariety/gulp-nodemon/issues/49