### PR TITLE
parse cmd.args

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -48,14 +48,14 @@ function run(options) {
     shFlag = '/c';
   }
 
-  cmd.args = cmd.args.map(function (arg) {
+  var args = cmd.args.map(function (arg) {
     if (arg.indexOf(' ') !== -1) {
       arg = '"' + arg.replace(/"/g, '\\"') + '"';
     }
     return arg;
   });
 
-  var args = [cmd.executable].concat(cmd.args).join(' ').trim();
+  args = [cmd.executable].concat(args).join(' ').trim();
   var spawnArgs = [sh, [shFlag, args]];
 
   if (nodeMajor === 0 && nodeMinor < 8) {


### PR DESCRIPTION
use nodemon as a require module:

```shell
$ npm install nodemon --save
```

```javascript
var nodemon = require('nodemon');

nodemon({
    script: 'app.js',
    args: ['--port 10086', '--delay 2000'],
    nodeArgs: ['--harmony'],
    watch: '/path/to/watch',
    ext: 'json,js'
}).on('restart', function (files) {
});
```

when nodemon emit **restart** event, an error occurred because of the args is missing.

It also get the error when you run nodemon in the shell when it restarts:

```shell
$ nodemon --harmony -e "js, json" -w '/path/to/watch' app.js "--prot 10086" "--delay 2000"
```

in [`lib/monitor/run.js#L51-L58`](https://github.com/remy/nodemon/blob/master/lib/monitor/run.js#L51-L58) cause this error:


```javascript
cmd.args = cmd.args.map(function (arg) {
    if (arg.indexOf(' ') !== -1) {
        arg = '"' + arg.replace(/"/g, '\\"') + '"';
    }
    return arg;
});

var args = [cmd.executable].concat(cmd.args).join(' ').trim();
```

when nodemon start, `cmd.args` will be wrapped by `"`. `cmd.args` is an object, when nodemon restart, `cmd.args` will be wrapped by `"` again. The program could not get the args correctly, the error happens.

So, don't to change `cmd.args`, keep it the same as when the nodemon starts.

```javascript
var args = cmd.args.map(function (arg) {
    if (arg.indexOf(' ') !== -1) {
      arg = '"' + arg.replace(/"/g, '\\"') + '"';
    }
    return arg;
});

args = [cmd.executable].concat(args).join(' ').trim();
```

it works fine.
