### PR TITLE
Fixed #476

### DIFF
--- a/lib/monitor/offset.js
+++ b/lib/monitor/offset.js
@@ -11,13 +11,16 @@ module.exports = function () {
   }
 
   if (offset === null) {
-    fs.writeFileSync(filename, 'offset-test');
-    var stat = fs.statSync(filename);
-    var hostTime = stat.mtime.getTime();
-    fs.unlinkSync(filename);
-    var clientTime = Date.now();
-
-    offset = hostTime - clientTime;
+    try { // being lazy, but sometimes we can't write the offset file
+      fs.writeFileSync(filename, 'offset-test');
+      var stat = fs.statSync(filename);
+      var hostTime = stat.mtime.getTime();
+      fs.unlinkSync(filename);
+      var clientTime = Date.now();
+      offset = hostTime - clientTime;
+    } catch (e) {
+      offset = 0;
+    }
   }
 
   if (offset < 1000) {


### PR DESCRIPTION
Use try/catch when trying to work out the offset, because if we don't have permission, we shouldn't vomit.