### PR TITLE
Fix/482

### DIFF
--- a/lib/monitor/match.js
+++ b/lib/monitor/match.js
@@ -165,19 +165,25 @@ function match(files, monitor, ext) {
       whitelist = [], // files that we won't check against the extension
       ignored = 0,
       watched = 0,
-      usedRules = [];
+      usedRules = [],
+      minimatchOpts = {};
+
+  // enable case-insensitivity on Windows
+  if (utils.isWindows) {
+    minimatchOpts.nocase = true;
+  }
 
   files.forEach(function (file) {
     var matched = false;
     for (var i = 0; i < rules.length; i++) {
       if (rules[i].slice(0, 1) === '!') {
-        if (!minimatch(file, rules[i])) {
+        if (!minimatch(file, rules[i], minimatchOpts)) {
           ignored++;
           matched = true;
           break;
         }
       } else {
-        if (minimatch(file, rules[i])) {
+        if (minimatch(file, rules[i], minimatchOpts)) {
           watched++;
 
           // don't repeat the output if a rule is matched
@@ -219,7 +225,7 @@ function match(files, monitor, ext) {
 
     good = good.filter(function(file) {
       // only compare the filename to the extension test, so we use path.basename
-      return minimatch(path.basename(file), ext);
+      return minimatch(path.basename(file), ext, minimatchOpts);
     });
   } // else assume *.*
 

--- a/test/monitor/match.test.js
+++ b/test/monitor/match.test.js
@@ -189,6 +189,14 @@ describe('match', function () {
       done();
     });
   });
+
+  it('should ignore case when comparing paths on Windows', function () {
+    if (!nodemonUtils.isWindows) {
+      return;
+    }
+    var results = match(['C:\\TEST\\fixtures'], ['c:\\test\\fixtures']);
+    assert(results.result.length === 1, 'matched ' + results.result.length);
+  });
 });
 
 describe('validating files that cause restart', function () {


### PR DESCRIPTION
Enables the minimatch option `nocase` when running on Windows. Not only does it fix #482 but it also makes nodemon compare paths as expected on Windows, which is in a case-insensitive way.

I did not remove the code that uppercases the drive letter (`watch.js:246`) because I am unsure of its purpose. The test suite was not very helpful in detecting breakage as it does not seem to run properly on my machine (because of Windows?). Many tests simply fail after a clean checkout of `master`. I might have a look at that later.

Note also that file names containing double quotes or backslashes (found in `tests/fixtures`) cannot be successfully checked out on Windows, which makes working with the repository a little tricky.