### PR TITLE
Fixed #499

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "0.12"
   - "0.11"
   - "0.10"
   - "0.8"

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -12,8 +12,6 @@ var utils = require('../utils'),
     noop = function() {},
     restart = null,
     psTree = require('ps-tree'),
-    nodeMajor = parseInt((process.versions.node.split('.') || [null,null])[0] || 0, 10),
-    nodeMinor = parseInt((process.versions.node.split('.') || [null,null])[1] || 0, 10),
     hasPS = true;
 
 // discover if the OS has `ps`, and therefore can use psTree
@@ -72,7 +70,7 @@ function run(options) {
 
   var spawnArgs = [sh, [shFlag, args]];
 
-  if (nodeMajor === 0 && nodeMinor < 8) {
+  if (utils.version.major === 0 && utils.version.minor < 8) {
     // use the old spawn args :-\
   } else {
     spawnArgs.push({
@@ -204,7 +202,11 @@ function run(options) {
           // though I'm unsure why. it seems like more data is streamed in to
           // stdin after we close.
           if (child && options.stdin && oldPid === child.pid) {
-            child.stdin.end();
+            // this is stupid and horrible, but node 0.12 on windows blows up
+            // with this line, so we'll skip it entirely.
+            if (!utils.isWindows) {
+              child.stdin.end();
+            }
           }
           callback();
         });

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,8 +1,15 @@
 'use strict';
 var noop = function () {},
-    path = require('path');
+    path = require('path'),
+    version = process.versions.node.split('.') || [null, null, null];
+
 
 var utils = module.exports = {
+  version: {
+    major: parseInt(version[0] || 0, 10),
+    minor: parseInt(version[1] || 0, 10),
+    patch: parseInt(version[2] || 0, 10),
+  },
   clone: require('./clone'),
   merge: require('./merge'),
   bus: require('./bus'),


### PR DESCRIPTION
`rs` now works again on windows when app has crashed.