### PR TITLE
Fix nodemon.json's 'quit' listener and add test.

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -271,7 +271,7 @@ run.kill = function (flag, callback) {
 };
 run.restart = noop;
 
-bus.on('quit', function () {
+bus.on('quit', function onQuit() {
   // remove event listener
   var exitTimer = null;
   var exit = function () {
@@ -279,6 +279,12 @@ bus.on('quit', function () {
     exit = noop; // null out in case of race condition
     child = null;
     if (!config.required) {
+      // Execute all other quit listeners.
+      bus.listeners('quit').forEach(function(listener) {
+        if (listener !== onQuit) {
+          listener();
+        }
+      });
       process.exit(0);
     } else {
       bus.emit('exit');
@@ -321,28 +327,11 @@ process.on('exit', function () {
 if (!utils.isWindows) {
   // usual suspect: ctrl+c exit
   process.once('SIGINT', function () {
-    var exitTimer = null;
-    var exit = function () {
-          clearTimeout(exitTimer);
-          bus.emit('exit');
-          exit = noop;
-          if (child) { child.kill('SIGINT'); }
-          process.exit(0);
-        };
-
-    if (child) {
-      child.removeAllListeners('exit');
-      child.on('exit', exit);
-      child.kill('SIGINT');
-      // give up waiting for the kids after 10 seconds,
-      // this is usually when the child is capturing the SIGINT
-      exitTimer = setTimeout(exit, 10 * 1000);
-    } else {
-      exit();
-    }
+    bus.emit('quit');
   });
 
   process.once('SIGTERM', function () {
+    bus.emit('quit');
     if (child) { child.kill('SIGTERM'); }
     process.exit(0);
   });

--- a/test/fixtures/events/nodemon.json
+++ b/test/fixtures/events/nodemon.json
@@ -4,6 +4,7 @@
   "events": {
     "start": "echo 'OK'",
     "crash": "echo 'CRASHED'",
-    "exit": "echo 'STOPPED'"
+    "exit": "echo 'STOPPED'",
+    "quit": "echo 'QUIT'"
   }
 }


### PR DESCRIPTION
Previously, a `'quit'` listener in `nodemon.json` would not execute.

This is useful to have for cleanup in various cases. I was putting together a `nodemon.json` that was compatible with [naught](https://github.com/andrewrk/naught) in my case but I am sure there are plenty of others.

This patch simply iterates through all other `'quit'` listeners before calling `process.exit(0)`, to make sure they execute.

I have additionally removed some duplicated code in the SIGINT handler and added a test.