### PR TITLE
spawn: Change node version checking logic

### DIFF
--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -2,7 +2,6 @@
 var utils = require('./utils'),
     merge = utils.merge,
     bus = utils.bus,
-    nodeMajor = parseInt((process.versions.node.split('.') || [null,null])[1] || 0, 10),
     childProcess = require('child_process'),
     _spawn = childProcess.spawn;
 
@@ -37,7 +36,7 @@ module.exports = function spawn(command, config, eventArgs) {
 
   args = command.join(' ');
 
-  if (nodeMajor >= 8) {
+  if (utils.version.major >= 1 || utils.version.minor >= 8) {
     var env = merge(process.env, { FILENAME: eventArgs[0] } );
     child = _spawn(sh, [shFlag, args], {
       env: merge(config.options.execOptions.env, env),

--- a/test/monitor/ignore.test.js
+++ b/test/monitor/ignore.test.js
@@ -53,8 +53,11 @@ function ignore(rule, done, file) {
 }
 
 describe('nodemon ignore', function () {
-  after(function () {
-    files.forEach(fs.unlink);
+  after(function (done) {
+    files.forEach(function(file) {
+      fs.unlink(file, function() {});
+    });
+    done();
   });
 
   it('should be controlled via cli', function (done) {


### PR DESCRIPTION
This change allows nodemon to properly work with all versions of io.js.
This fixes #509