### PR TITLE
README specifies incorrect format for extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Now nodemon will only restart if there are changes in the `./app` or `./libs` di
 
 By default, nodemon looks for files with the `.js`, `.coffee`, and `.litcoffee` extensions. If you use the `--exec` option and monitor `app.py` nodemon will monitor files with the extension of `.py`. However, you can specify your own list with the `-e` (or `--ext`) switch like so:
 
-    nodemon -e js,jade
+    nodemon -e "js jade"
 
 Now nodemon will restart on any changes to files in the directory (or subdirectories) with the extensions .js, .jade.
 


### PR DESCRIPTION
The README specifies a different format for the list passed to `--ext` than the output of `--help` does, and it seems incorrect.