### PR TITLE
--watch doesn't work in windows

### DIFF
--- a/lib/monitor/match.js
+++ b/lib/monitor/match.js
@@ -66,8 +66,10 @@ function rulesToMonitor(watch, ignore, config) {
         // only needed for mac, because on mac we use `find` and it needs some
         // narrowing down otherwise it tries to find on the entire drive...which
         // is a bit batty.
+        // Need, in general, for --watch to work, otherwise watchers are only
+        // create for files under cwd().
         // `!not` ... sorry.
-        if (config.system.useFind && !not) {
+        if (!not) {
           config.dirs.push(dir);
         }
       } else {

--- a/test/monitor/match.test.js
+++ b/test/monitor/match.test.js
@@ -21,6 +21,15 @@ describe('match', function () {
     '!*.coffee',
   ];
 
+  // Make sure all tests set the cwd back
+  var cwd;
+  beforeEach(function () {
+    cwd = process.cwd();
+  });
+  afterEach(function () {
+    process.chdir(cwd);
+  });
+
   it('should match zero files', function () {
     var files = [
       'views/server/remy.coffee',
@@ -336,5 +345,21 @@ describe('match rule parser', function () {
     assert(settings.monitor[0] === path.resolve(pwd, '..') + '/**/*', 'path resolved: ' + settings.monitor[0]);
     var matched = match([script], settings.monitor, 'js');
     assert(matched.result.length === 1, 'no file matched');
+  });
+
+  it('should support "--watch .. in windows"', function () {
+    // make sure we're in a deep enough directory
+    process.chdir('./test/fixtures/');
+    var pwd = process.cwd();
+    var settings = merge({ watch: '..' }, defaults);
+    var script = pwd + 'index.js';
+
+    var config = { dirs: [], system: { useFind: false } };
+    settings.monitor = match.rulesToMonitor(settings.watch, [], config);
+
+    assert(settings.monitor[0] === path.resolve(pwd, '..') + '/**/*', 'path resolved: ' + settings.monitor[0]);
+    var matched = match([script], settings.monitor, 'js');
+    assert(matched.result.length === 1, 'no file matched');
+    assert(config.dirs[0] === path.resolve(pwd, '..'), 'starting dirs: '+JSON.stringify(config.dirs));
   });
 });


### PR DESCRIPTION
In windows watchers are created for all files under cwd(), then filtered based on --watch and --ignored when checking if a change should trigger a restart.

I have two problems with this.
First, I have a bunch of media files that get watchers but aren't under my --watch's so don't trigger a restart. But the watchers are there taking up a bunch of resources. --ignore didn't help either.
Second, I can't watch anything outside of cwd(). This isn't really a problem for me, but this was fixed too.
Is there a particular reason you're not filtering before doing fs[watchMethod] in monitor/watch.js?
This would save creating the watcher for files that don't match the desired extensions.

The simple fix is to put --watch'ed files/directories into config.dirs which is used the starting point for the watcher generation. This is the same behavior as "useFind".
```
        // only needed for mac, because on mac we use `find` and it needs some
        // narrowing down otherwise it tries to find on the entire drive...which
        // is a bit batty.
        // Need, in general, for --watch to work, otherwise watchers are only
        // create for files under cwd().
        // `!not` ... sorry.
        if (!not) {
          config.dirs.push(dir);
        }
```
This also changes/fixes legacyWatch, as this also starts at config.dirs.

I'm having some trouble with tests.

There are lots of errors in both Windows and ubuntu.
I added a new test in monitor/match.test.js showing the failur but these tests aren't reached even when running ```npm run-script ":test"``` on master.

I also had some trouble in match.test.js where an existing test failed, the assert throws an error, so the process.chdir(cwd) never gets called. This means that the cwd for the next tests are wrong.
I added a beforeEach and afterEach to handle the chdir outside of the test itself. I didn't touch the existing tests, so the chdir(cwd) is done twice now when the tests pass.


thanks,
-mikael
