### PR TITLE
Fixed restart "loop" due to VM clock out of sync with filesystem timestamps

### DIFF
--- a/lib/monitor/offset.js
+++ b/lib/monitor/offset.js
@@ -32,10 +32,14 @@ module.exports = function () {
   return offset;
 };
 
+module.exports.refresh = function() {
+  offset = null;
+};
+
 module.exports.pretty = function () {
   var date = new Date(offset);
   return two(date.getHours()) + 'h' + two(date.getMinutes()) + 'm' + two(date.getSeconds()) + 's';
-}
+};
 
 function two(s) {
   s += '';

--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -70,30 +70,30 @@ bus.on('config:update', function () {
     // command (mac only oddly)
     changeFunction = function (lastStarted, callback) {
       var cmds = [];
-      var delta = ((((Date.now() - config.lastStarted) * -1) + offset())/1000|0);
-      var mtime = utils.isMac ? '-mtime ' + delta + 's' : '-mmin ' + (delta/60);
+      var elapsedTime = Date.now() - config.lastStarted;
+      var delta = (offset() - elapsedTime) + 1000;  // 1000ms buffer to deal with gradual VM system clock desync
 
-      if (delta > 0) {
-        // we can't use -mmin or -mtime, we need to use -newer, and best bet is
-        // to touch a file with our reference timestamp, and search http://superuser.com/a/416191
-        touch.sync('.nodemon-find-ref', { time: new Date(Date.now() + (delta * 1000)) });
-        mtime = '-newer .nodemon-find-ref';
-      }
+      var findCondition;
+      var useReferenceTimestampFile = delta >= 0;
 
-      // don't run the find when delta is 0 seconds, otherwise
-      // nodemon goes into a barmy restart loop
-      if (delta === 0) {
-        return callback([]);
+      if (useReferenceTimestampFile) {
+        // find's -mmin or -mtime cannot be used with positive deltas,
+        // the alternative is to touch a file with a reference timestamp and use -newer
+        // see http://superuser.com/a/416191
+        touch.sync('.nodemon-find-ref', { time: new Date(Date.now() + delta) });
+        findCondition = '-newer .nodemon-find-ref';
+      } else {
+        findCondition = utils.isMac ? '-mtime ' + (delta/1000) + 's' : '-mmin ' + (delta/1000/60);
       }
 
       config.dirs.forEach(function(dir) {
-        cmds.push('find -L "' + dir + '" ' + ignoredFileTypesForFind(dir) + ' \\( -type f -and ' + mtime + ' -print \\)');
+        cmds.push('find -L "' + dir + '" ' + ignoredFileTypesForFind(dir) + ' \\( -type f -and ' + findCondition + ' -print \\)');
       });
 
       exec(cmds.join(';'), function (error, stdout) {
         var files = stdout.split(/\n/);
         files.pop(); // remove blank line ending and split
-        if (delta > 0) {
+        if (useReferenceTimestampFile) {
           try { fs.unlinkSync('.nodemon-find-ref'); }
           catch (e) {} // swallow any errors
         }
@@ -261,6 +261,9 @@ function filterAndRestart(files) {
 
     // reset the last check so we're only looking at recently modified files
     config.lastStarted = Date.now();
+
+    // refresh offset so nodemon doesn't go into barmy restart loop mode when VM clock is out of sync
+    offset.refresh();
 
     if (matched.result.length) {
       if (config.options.delay > 0) {

--- a/test/monitor/watch-restart.test.js
+++ b/test/monitor/watch-restart.test.js
@@ -45,7 +45,7 @@ describe('nodemon monitor child restart', function () {
       nodemon({ script: tmpjs, verbose: true, ext: 'js' }).on('start', function () {
         setTimeout(function () {
           touch.sync(tmpjs);
-        }, 1500);
+        }, 2500);
       }).on('restart', function (files) {
         assert(files[0] === tmpjs, 'nodemon restarted because of change to our file' + files);
         nodemon.once('exit', function () {
@@ -67,18 +67,13 @@ describe('nodemon monitor child restart', function () {
       }).on('start', function () {
         setTimeout(function () {
           touch.sync(tmpmd);
-        }, 1500);
-      }).on('log', function (event) {
-        var msg = event.message;
-        if (utils.match(msg, 'changes after filters')) {
-          var changes = msg.trim().slice(-5).split('/');
-          var restartedOn = changes.pop();
-          assert(restartedOn === '1', 'nodemon restarted on a single file change');
-          nodemon.once('exit', function () {
-            nodemon.reset();
-            done();
-          }).emit('quit');
-        }
+        }, 2500);
+      }).on('restart', function (files) {
+        assert(files[0] === tmpmd, 'nodemon restarted because of change to our file' + files);
+        nodemon.once('exit', function () {
+          nodemon.reset();
+          done();
+        }).emit('quit');
       });
     }, 2000);
   });
@@ -98,7 +93,7 @@ describe('nodemon monitor child restart', function () {
         }).on('start', function () {
           setTimeout(function () {
             touch.sync(tmpjs);
-          }, 1000);
+          }, 2500);
         }).on('restart', function (files) {
           assert(files.length === 1, 'nodemon restarted when watching directory');
           nodemon.once('exit', function () {
@@ -123,7 +118,7 @@ describe('nodemon monitor child restart', function () {
       }).on('start', function () {
         setTimeout(function () {
           touch.sync(tmpmd);
-        }, 1000);
+        }, 2500);
       }).on('restart', function (files) {
         assert(files.length === 1, 'nodemon restarted when watching directory');
         nodemon.once('exit', function () {


### PR DESCRIPTION
The "restart loop" issue can be caused by the system clock on the virtual machine becoming out of sync with the filesystem timestamps. The ```offset.js``` module is in place to address this issue, but the offset is only calculated during startup and does not take into account desync while nodemon is running. This can be replicated by putting the host machine to sleep (on OSX) for a few seconds while nodemon is running in the VM.

This patch addresses 2 issues:

1. The offset is updated every child process restart to prevent false positive change detection in the next ```find``` match due to incorrect delta values

2. The existing ```find``` delta value is quantized using a floor/ceiling function that produces incorrect positive delta values. For example, a ```1.9``` delta would be quantized to ```1``` and be used as the reference timestamp for ```find -newer```. This would find files changed after 1 second in the future instead of 1.9, returning more files than we want, including changes that have already been used to trigger previous finds.
