### PR TITLE
nodemon doesn't restart on changes - watch test failure

### DIFF
--- a/lib/config/watchable.js
+++ b/lib/config/watchable.js
@@ -45,6 +45,7 @@ function check(cb) {
   setTimeout(function () {
     // This should trigger fs.watch, if it works
     fs.writeSync(watchFile, '1');
+    fs.closeSync(watchFile);
 
     // higher timeout to allow for windows to trigger the watch event
     setTimeout(finish, 1000);


### PR DESCRIPTION
I've started using nodemon, and noticed it doesn't restart on changes.
After looking online and trying few stuff (none worked), I decided to dive in.

When using --dump, I noticed 'useWatch' was false.
I then tested fs.watch independently, and it worked.

After looking a bit more, I found nodemon is testing watch by waiting 1000 ms and assuming
a watch event should be triggered. I'm not sure why, but inside nodemon, the event seems to trigger only after 4 seconds (~);

When adding the fs.closeSync() line, the watch triggers, and everything works.

It shouldn't matter, but some extra information regarding my environment:
node: v0.12.2
nodemon: v1.3.7
OS: Windows 8.1 x64