### PR TITLE
Bump node-touch to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "minimatch": "~0.3.0",
     "ps-tree": "~0.0.3",
-    "touch": "~0.0.3",
+    "touch": "~1.0.0",
     "update-notifier": "^0.3.0"
   }
 }


### PR DESCRIPTION
[node-touch](https://github.com/isaacs/node-touch) has a bug where bin file is missing she-bang on version tagged v0.0.4 (automatically depended by nodemon) and impacting other modules depending on the bin file (such as libpq, bcrypt... on node-gyp rebuild cmd) thus breaking npm install.

Steps to reproduce
cd /tmp/
mkdir foo
cd foo
npm install touch@0.0.4
Install any lib that requires node-gyp rebuild
npm install libpq
