### PR TITLE
Fix a "unlimit" typo on comment

### DIFF
--- a/lib/config/checkWatchSupport.js
+++ b/lib/config/checkWatchSupport.js
@@ -40,7 +40,7 @@ function checkWatchSupport(config, callback) {
 
   // Note: we're purposely putting Mac over to the `find` command.
   // this is because it has a default ulimit of 256 - which is WAY LOW,
-  // and without asking the user to `unlimit -n <BIG-ASS-NUMBER>` it'll throw
+  // and without asking the user to `ulimit -n <BIG-ASS-NUMBER>` it'll throw
   // up all over your screen like this: http://d.pr/i/R6B8+
   // even with higher ulimit -n Mac has another problem: https://github.com/joyent/node/issues/5463
   // This will be fixed in 0.12, before then we default to find


### PR DESCRIPTION
It seems to be correct in `unlimit` rather than `ulimit`.