### PR TITLE
fix: restore --legacy-watch

### DIFF
--- a/lib/cli/parse.js
+++ b/lib/cli/parse.js
@@ -131,6 +131,10 @@ function nodemonOption(options, arg, eatNext) {
     options.verbose = true;
   } else
 
+  if (arg === '--legacy-watch' || arg === '-L') {
+    options.legacyWatch = true;
+  } else
+
   // Depricated as this is "on" by default
   if (arg === '--js') {
     options.js = true;

--- a/lib/config/load.js
+++ b/lib/config/load.js
@@ -136,8 +136,6 @@ function normaliseRules(options, ready) {
   options.watch = rules.rules.watch;
   options.ignore = rules.rules.ignore;
 
-  debug('final rules', options);
-
   ready(options);
 }
 

--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -52,6 +52,7 @@ function watch() {
       var watcher = chokidar.watch(dir, {
         ignored: ignored,
         persistent: true,
+        usePolling: config.options.legacyWatch || false,
       });
 
       var total = 0;

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   "scripts": {
     "coverage": "istanbul cover _mocha -- --timeout 30000 --ui bdd --reporter list test/**/*.test.js",
     "lint": "jscs lib/**/*.js -v",
-    "spec": "node_modules/.bin/mocha --timeout 30000 --ui bdd test/**/*.test.js",
+    ":spec": "node_modules/.bin/mocha --timeout 30000 --ui bdd test/**/*.test.js",
     "test": "npm run lint && npm run spec",
-    ":test": "for FILE in test/**/*.test.js; do echo $FILE; ./node_modules/.bin/mocha --timeout 30000 $FILE; if [ $? -ne 0 ]; then exit 1; fi; sleep 1; done",
+    "spec": "for FILE in test/**/*.test.js; do echo $FILE; ./node_modules/.bin/mocha --timeout 30000 $FILE; if [ $? -ne 0 ]; then exit 1; fi; sleep 1; done",
     "web": "node web",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },

--- a/test/cli/parse.test.js
+++ b/test/cli/parse.test.js
@@ -39,7 +39,7 @@ describe('nodemon CLI parser', function () {
     var settings = parse(asCLI('--debug'));
     var cmd = commandToString(command(settings));
     process.chdir(cwd);
-    assert(cmd === 'node --debug ./bin/www')
+    assert(cmd === 'node --debug ./bin/www');
   });
 
   it('should replace {{filename}}', function () {

--- a/test/fork/watch-restart.test.js
+++ b/test/fork/watch-restart.test.js
@@ -156,7 +156,7 @@ describe('nodemon fork child restart', function () {
           if (monitor(msg)) {
             var changes = msg.slice(-5).split('/');
             var restartedOn = changes.pop();
-            assert(restartedOn === '1', 'nodemon restarted on a single file change: ' + restartedOn);
+            assert.equal(restartedOn, '1', 'nodemon restarted on a single file change: ' + restartedOn + ' -- ' + msg);
             cleanup(p, done);
           }
         }

--- a/test/monitor/match.test.js
+++ b/test/monitor/match.test.js
@@ -344,6 +344,7 @@ describe('match rule parser', function () {
 describe('watcher', function () {
   afterEach(function () {
     watch.resetWatchers();
+    config.reset();
   });
 
   it('should match a dotfile if explicitly asked to', function (done) {


### PR DESCRIPTION
Pass the `usePolling` flag to Chokidar when in legacy mode, which is supposed to/hopefully fix containers watching network attached drives.

Fixes #639
Fixes #633