### PR TITLE
fix: JSON extension not watched outside of coffeescript

### DIFF
--- a/lib/config/exec.js
+++ b/lib/config/exec.js
@@ -73,13 +73,8 @@ function exec(nodemonOptions, execMap) {
   var options = utils.clone(nodemonOptions || {});
   var script = path.basename(options.script || '');
   var scriptExt = path.extname(script).slice(1);
-  var extension = options.ext || scriptExt || 'js';
+  var extension = options.ext || scriptExt || 'js,json';
   var execDefined = !!options.exec;
-
-  // strip any leading periods int he extension
-  if (extension.indexOf('.') === 0) {
-    extension = extension.slice(1);
-  }
 
   // allows the user to simplify cli usage:
   // https://github.com/remy/nodemon/issues/195
@@ -146,7 +141,7 @@ function exec(nodemonOptions, execMap) {
   if (options.exec === 'coffee') {
     // don't override user specified extension tracking
     if (!options.ext) {
-      extension = 'coffee litcoffee js json';
+      extension = 'coffee,litcoffee,js,json';
     }
 
     // because windows can't find 'coffee', it needs the real file 'coffee.cmd'
@@ -156,22 +151,11 @@ function exec(nodemonOptions, execMap) {
   }
 
   // allow users to make a mistake on the extension to monitor
-  // converts js,jade => js,jade
-  // and 'js jade' => js,jade
+  // converts .js, jade => js,jade
   // BIG NOTE: user can't do this: nodemon -e *.js
   // because the terminal will automatically expand the glob against
   // the file system :(
-  if (extension.indexOf(' ') !== -1 ||
-      extension.indexOf(',') !== -1 ||
-      extension.indexOf('*.') !== -1) {
-
-    extension = extension.replace(/\s+/g, '|') // convert spaces to pipes
-      .replace(/,/g, '|') // convert commas to pipes
-      .split('|') // split on those pipes
-      .map(function (item) {
-        return item.replace(/^[\*\.]+/, ''); // remove "*."
-      }).join(','); // return regexp string like: js,jade
-  }
+  extension = extension.match(/\w+/g).join(',');
 
   options.ext = extension;
 


### PR DESCRIPTION
Fix a bug that caused `.json` file to not be watched outside of a coffeescript environment,
and improves the extension formatting regex.