### PR TITLE
Bump ps-tree dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "es6-promise": "3.0.2",
     "lodash.defaults": "3.1.2",
     "minimatch": "~0.3.0",
-    "ps-tree": "~0.0.3",
+    "ps-tree": "^1.0.1",
     "touch": "1.0.0",
     "undefsafe": "0.0.3",
     "update-notifier": "0.5.0"


### PR DESCRIPTION
Solves toolchain warning about missing SPDX license in outdated
dependency ps-tree@0.0.3 -> event-stream@0.5.3 -> optimist@0.2.8.