### PR TITLE
fix: JSON extension not watched when "scriptExt" is defined

### DIFF
--- a/lib/config/exec.js
+++ b/lib/config/exec.js
@@ -73,7 +73,7 @@ function exec(nodemonOptions, execMap) {
   var options = utils.clone(nodemonOptions || {});
   var script = path.basename(options.script || '');
   var scriptExt = path.extname(script).slice(1);
-  var extension = options.ext || scriptExt || 'js,json';
+  var extension = options.ext || scriptExt + ',json' || 'js,json';
   var execDefined = !!options.exec;
 
   // allows the user to simplify cli usage:


### PR DESCRIPTION
Fix a bug that caused ".json" files to not be watched by default.

closes #643