### PR TITLE
refactor: remove deprecated util.error

### DIFF
--- a/lib/config/load.js
+++ b/lib/config/load.js
@@ -179,6 +179,7 @@ function loadFile(options, config, dir, ready) {
     } catch (e) {
       console.error(e);
       utils.log.fail('Failed to parse config ' + filename);
+      process.exit(1);
     }
 
     // options values will overwrite settings

--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -1,4 +1,3 @@
-var util = require('util');
 var colour = require('./colour');
 var bus = require('./bus');
 var required = false;
@@ -27,9 +26,9 @@ function log(type, text) {
   // question: should we actually just consume our own events?
   if (!required) {
     if (type === 'error') {
-      util.error(msg);
+      console.error(msg);
     } else {
-      util.log(msg);
+      console.log(msg || '');
     }
   }
 }
@@ -62,7 +61,7 @@ Logger.prototype._log = function (type, msg) {
   if (required) {
     bus.emit('log', { type: type, message: msg || '', colour: msg || '' });
   } else if (type === 'error') {
-    util.error(msg);
+    console.error(msg);
   } else {
     console.log(msg || '');
   }


### PR DESCRIPTION
Replace with console.error
Replace util.log with console.log to be consistent with _log