### PR TITLE
Watch js, json files by default

### DIFF
--- a/lib/config/exec.js
+++ b/lib/config/exec.js
@@ -73,7 +73,7 @@ function exec(nodemonOptions, execMap) {
   var options = utils.clone(nodemonOptions || {});
   var script = path.basename(options.script || '');
   var scriptExt = path.extname(script).slice(1);
-  var extension = options.ext || scriptExt + ',json' || 'js,json';
+  var extension = options.ext || (scriptExt ? scriptExt + ',json' : 'js,json');
   var execDefined = !!options.exec;
 
   // allows the user to simplify cli usage:


### PR DESCRIPTION
In node the file extension is optional, so by default nodemon should watch
js and json files.

Closes #710