### PR TITLE
Fixed a typo

### DIFF
--- a/doc/option-parsing-logic.md
+++ b/doc/option-parsing-logic.md
@@ -2,7 +2,7 @@
 
 1. Read all CLI arguments
 2. Load local config
-3. Loal global config
+3. Load global config
 4. Try backup: package.main
 5. Try backup: package.start
 6. Try index.js


### PR DESCRIPTION
Fixed a typo in `doc/option-parsing-logic.md`.