### PR TITLE
feat: support --polling-interval command line arg

### DIFF
--- a/lib/cli/parse.js
+++ b/lib/cli/parse.js
@@ -135,6 +135,10 @@ function nodemonOption(options, arg, eatNext) {
     options.legacyWatch = true;
   } else
 
+  if (arg === '--polling-interval' || arg === '-P') {
+    options.pollingInterval = parseInt(eatNext(), 10);
+  } else
+
   // Depricated as this is "on" by default
   if (arg === '--js') {
     options.js = true;

--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -53,6 +53,7 @@ function watch() {
         ignored: ignored,
         persistent: true,
         usePolling: config.options.legacyWatch || false,
+        interval: config.options.pollingInterval,
       });
 
       watcher.ready = false;


### PR DESCRIPTION
Passes a polling interval to chokidar.watch() for legacy polling. Very useful for those of us running nodemon in a docker-machine image / VirtualBox VM.