### PR TITLE
load: Add ability to specify custom config file

### DIFF
--- a/lib/config/load.js
+++ b/lib/config/load.js
@@ -165,7 +165,7 @@ function loadFile(options, config, dir, ready) {
     return callback({});
   }
 
-  var filename = path.join(dir, 'nodemon.json');
+  var filename = settings.config || path.join(dir, 'nodemon.json');
   fs.readFile(filename, 'utf8', function (err, data) {
     if (err) {
       return callback({});


### PR DESCRIPTION
Specified via the `--config` flag

Hey @remy,
This PR is my way of asking you whether you're cool with doing something like this. I thought it'd be more helpful than an issue. I'm not sure whether this actually works, and I just made the change in the GitHub editor. If you're cool with this feature and you want me to, I'd be happy to make a legit PR with tests etc.

The reason for this is because I have a server that uses `nodemon.json` to configure how the server should run, but in addition, I have tasks (specifically to run [ava](http://npm.im/ava)) which require quite a different configuration. I'm sure I could do all of this with the CLI, but I'd rather not if I can help it :-)

Let me know what you think.