### PR TITLE
Fix buildup of ignored option for Chokidar

### DIFF
--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -46,7 +46,7 @@ function watch() {
 
       // don't ignore dotfiles if explicitly watched.
       if (!dir.match(dotFilePattern)) {
-        ignored = new RegExp(ignored.source + dotFilePattern.source);
+        ignored = [ignored, dotFilePattern];
       }
 
       var watcher = chokidar.watch(dir, {

--- a/test/monitor/match.test.js
+++ b/test/monitor/match.test.js
@@ -360,6 +360,22 @@ describe('watcher', function () {
     })
   });
 
+  it('should not match a dotfile unless explicitly asked to', function (done) {
+    config.load({
+      watch: ['test/fixtures/*']
+    }, function (config) {
+      return watch.watch()
+          .then(function (files) {
+            var withDotfile = files.filter(function (file) {
+              return /test\/fixtures\/\.dotfile$/.test(file);
+            });
+            assert.deepEqual(withDotfile.length, 0, 'should not contain .dotfile');
+            done();
+          })
+          .catch(done);
+    })
+  });
+
   it('should match a dotfile if explicitly asked to', function (done) {
     config.load({
       watch: ['test/fixtures/.dotfile']

--- a/test/monitor/match.test.js
+++ b/test/monitor/match.test.js
@@ -342,10 +342,23 @@ describe('match rule parser', function () {
 
 
 describe('watcher', function () {
-  // afterEach(function () {
-  //   config.reset();
-  //   watch.resetWatchers();
-  // });
+  afterEach(function () {
+    config.reset();
+    watch.resetWatchers();
+  });
+
+  it('should not crash if ignoreRoot is an empty array', function (done) {
+    config.load({
+      watch: ['test/fixtures/app.js'],
+      ignoreRoot: []
+    }, function (config) {
+      return watch.watch()
+          .then(function () {
+            done();
+          })
+          .catch(done)
+    })
+  });
 
   it('should match a dotfile if explicitly asked to', function (done) {
     config.load({


### PR DESCRIPTION
I found some bugs in how dotfiles are not ignored if explicitly watched. This code was introduced in #634. 

If the initial `ignored` is undefined there's a crash. Otherwise the dotfile pattern is appended to the expression, invalidating its last part. E.g. `/\.git|node_modules|bower_components|\.sass\-cache/` becomes `/\.git|node_modules|bower_components|\.sass\-cache[\/\\]\./`. It should have been `/\.git|node_modules|bower_components|\.sass\-cache|[\/\\]\./`

The fix is to construct an array again, as was done in the original code. An undefined `ignored` will be ignored by Chokidar (no pun intended), and there are no regex concatenation problems.

I did a quick scan of the issues list. I believe this may be the root cause of #762 and #723.

Test output before the fix commit:

```
$(npm bin)/mocha --ui bdd test/monitor/match.test.js

[...]

watcher
    1) should not crash if ignoreRoot is an empty array
    2) should not match a dotfile unless explicitly asked to
    ✓ should match a dotfile if explicitly asked to


  25 passing (274ms)
  2 failing

  1) watcher should not crash if ignoreRoot is an empty array:
     TypeError: Cannot read property 'source' of undefined
      at lib/monitor/watch.js:49:37
      at lib$es6$promise$$internal$$initializePromise (node_modules/es6-promise/dist/es6-promise.js:373:9)
      at new lib$es6$promise$promise$$Promise (node_modules/es6-promise/dist/es6-promise.js:664:9)
      at lib/monitor/watch.js:43:19
      at Array.forEach (native)
      at Object.watch (lib/monitor/watch.js:42:8)
      at test/monitor/match.test.js:355:20
      at lib/config/index.js:79:7
      at lib$es6$promise$$internal$$tryCatch (node_modules/es6-promise/dist/es6-promise.js:326:16)
      at lib$es6$promise$$internal$$invokeCallback (node_modules/es6-promise/dist/es6-promise.js:338:17)
      at lib$es6$promise$$internal$$publish (node_modules/es6-promise/dist/es6-promise.js:309:11)
      at lib$es6$promise$asap$$flush (node_modules/es6-promise/dist/es6-promise.js:120:9)

  2) watcher should not match a dotfile unless explicitly asked to:

      AssertionError: should not contain .dotfile
      + expected - actual

      -1
      +0

      at test/monitor/match.test.js:372:20
      at lib$es6$promise$$internal$$tryCatch (node_modules/es6-promise/dist/es6-promise.js:326:16)
      at lib$es6$promise$$internal$$invokeCallback (node_modules/es6-promise/dist/es6-promise.js:338:17)
      at lib$es6$promise$$internal$$publish (node_modules/es6-promise/dist/es6-promise.js:309:11)
      at lib$es6$promise$asap$$flush (node_modules/es6-promise/dist/es6-promise.js:120:9)
```