### PR TITLE
Get default ignoreRoot from ignore-by-default

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -1,3 +1,5 @@
+var ignoreRoot = require('ignore-by-default').directories()
+
 // default options for config.options
 module.exports = {
   restartable: 'rs',
@@ -9,7 +11,7 @@ module.exports = {
     // compatible with linux, mac and windows, or make the default.js
     // dynamically append the `.cmd` for node based utilities
   },
-  ignoreRoot: ['.git', 'node_modules', 'bower_components', '.sass-cache'],
+  ignoreRoot: ignoreRoot,
   watch: ['*.*'],
   stdin: true,
   runOnChangeOnly: false,

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "chokidar": "^1.2.0",
     "debug": "^2.2.0",
     "es6-promise": "^3.0.2",
+    "ignore-by-default": "^1.0.0",
     "lodash.defaults": "^3.1.2",
     "minimatch": "^3.0.0",
     "ps-tree": "^1.0.1",


### PR DESCRIPTION
Hello!

I'm [adding `--watch` support to AVA](https://github.com/sindresorhus/ava/pull/502). Like nodemon it uses Chokidar to watch for changes, and like nodemon it should ignore non-code directories. Initially I copied the `ignoreRoot` config from here but it seemed like the list of directories to ignore should be in a package of its own. That way multiple projects can share good defaults :100: 

This PR switches the default `ignoreRoot` to a list obtained from the [`ignore-by-default` package](https://github.com/novemberborn/ignore-by-default). Compared to the original list in nodemon this adds `.nyc_output` and `coverage` directories.

I marked this as a `refactor`, but maybe it should be a `feature` instead. If so maybe the `ignore-by-default` dependency should be pinned to an exact release so changes won't impact nodemon.

This requires #778 to land first, otherwise that bug causes test breakage in this PR.