### PR TITLE
Don't watch for 'rs' when --no-stdin is provided

### DIFF
--- a/lib/nodemon.js
+++ b/lib/nodemon.js
@@ -89,7 +89,7 @@ function nodemon(settings) {
     });
 
     // echo out notices about running state
-    if (config.options.restartable) {
+    if (config.options.stdin && config.options.restartable) {
       // allow nodemon to restart when the use types 'rs\n'
       process.stdin.resume();
       process.stdin.setEncoding('utf8');


### PR DESCRIPTION
Use case: in my ``package.json`` I have two "nodemon" entries, one for linting and the other one for my real server. I run them all in parallel and when I type "rs" I want only one of them to catch it.
As I cannot configure them individually (shared nodemon.json), I added "--no-stdin" to one, but I found it weird that it did not do what was expected.

This patch will make "--no-stdin" actually do what it claims and stop listening for stdin, even if "restartable" is enabled.