### PR TITLE
load: Add ability to specify custom config file (reboot). fixes #755

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Whilst nodemon is running, if you need to manually restart your application, ins
 
 ## Config files
 
-nodemon supports local and global configuration files. These are named `nodemon.json` and can be located in the current working directory or in your home directory.
+nodemon supports local and global configuration files. These are usually named `nodemon.json` and can be located in the current working directory or in your home directory. An alternative local configuration file can be specified with the `--config <file>` option.
 
 The specificity is as follows, so that a command line argument will always override the config file settings:
 

--- a/doc/cli/config.txt
+++ b/doc/cli/config.txt
@@ -5,7 +5,7 @@
   nodemon can also be configured via a local and global config file:
 
   * $HOME/nodemon.json
-  * $PWD/nodemon.json
+  * $PWD/nodemon.json OR --config <file>
 
   All config options in the .json file map 1-to-1 with the CLI options, so a
   config could read as:

--- a/doc/cli/help.txt
+++ b/doc/cli/help.txt
@@ -2,6 +2,7 @@
 
   Options:
 
+  --config file ............ alternate nodemon.json config file to use
   -e, --ext ................ extensions to look for, ie. js,jade,hbs.
   -x, --exec app ........... execute script with "app", ie. -x "python -v".
   -w, --watch dir........... watch directory "dir" or files. use once for
@@ -30,6 +31,7 @@
   Examples:
 
   $ nodemon server.js
+  $ nodemon --config my/custom/nodemon.json server.js
   $ nodemon -w ../foo server.js apparg1 apparg2
   $ PORT=8000 nodemon --debug-brk server.js
   $ nodemon --exec python app.py

--- a/lib/cli/parse.js
+++ b/lib/cli/parse.js
@@ -152,6 +152,10 @@ function nodemonOption(options, arg, eatNext) {
     options.hidden = true;
   } else
 
+  if (arg === '--config') {
+    options.configFile = eatNext();
+  } else
+
   if (arg === '--watch' || arg === '-w') {
     if (!options.watch) { options.watch = []; }
     options.watch.push(eatNext());

--- a/lib/config/load.js
+++ b/lib/config/load.js
@@ -22,7 +22,10 @@ function load(settings, options, config, callback) {
   config.loaded = [];
   // first load the root nodemon.json
   loadFile(options, config, utils.home, function (options) {
-    // then load the user's local nodemon.json
+    // then load the user's local configuration file
+    if (settings.configFile) {
+      options.configFile = path.resolve(settings.configFile);
+    }
     loadFile(options, config, process.cwd(), function (options) {
       // Then merge over with the user settings (parsed from the cli).
       // Note that merge protects and favours existing values over new values,
@@ -165,7 +168,7 @@ function loadFile(options, config, dir, ready) {
     return callback({});
   }
 
-  var filename = path.join(dir, 'nodemon.json');
+  var filename = options.configFile || path.join(dir, 'nodemon.json');
   fs.readFile(filename, 'utf8', function (err, data) {
     if (err) {
       return callback({});

--- a/test/cli/parse.test.js
+++ b/test/cli/parse.test.js
@@ -186,6 +186,13 @@ describe('nodemon CLI parser', function () {
     assert(settings.script === 'lib/index.js');
   });
 
+  it('should parse `nodemon --config my/.nodemon.json server.js`', function () {
+    var settings = parse(asCLI('--config my/.nodemon.json test/fixtures/app.js'));
+
+    assert(settings.configFile === 'my/.nodemon.json');
+    assert(settings.script === 'test/fixtures/app.js');
+  });
+
   it('should parse `nodemon test/fixtures/app.coffee`', function () {
     var settings = parse(asCLI('test/fixtures/app.coffee'));
 
@@ -240,7 +247,7 @@ describe('nodemon argument parser', function () {
 
 
   it('should support long versions of flags', function () {
-    var settings = cli.parse('node nodemon --version --exec java --verbose --quiet --watch fixtures --ignore fixtures --no-stdin --delay 5 --legacy-watch --exitcrash --on-change-only --ext jade');
+    var settings = cli.parse('node nodemon --version --exec java --verbose --quiet --watch fixtures --ignore fixtures --no-stdin --delay 5 --legacy-watch --exitcrash --on-change-only --ext jade --config my/.nodemon.json');
     assert(settings.version, 'version');
     assert(settings.verbose, 'verbose');
     assert(settings.exec === 'java', 'exec');
@@ -252,6 +259,7 @@ describe('nodemon argument parser', function () {
     assert(settings.delay === 5000, 'delay 5 seconds');
     assert(settings.runOnChangeOnly, 'run on change only');
     assert(settings.ext === 'jade', 'extension is jade');
+    assert(settings.configFile === 'my/.nodemon.json', 'custom config file name is my/.nodemon.json')
   });
 });
 


### PR DESCRIPTION
Per original PR / conversation by @kentcdodds & @remy in #755, this implements
the `--config <file>` option allowing users to load an arbitrary config file
instead of being bound to the default `$PWD/nodemon.json`.

Patch includes:
* `--config` option parsing
* Documentation updates
* light (maybe sufficient?) unit test coverage