### PR TITLE
Include TypeScript files by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Don't use unix globbing to pass multiple directories, e.g `--watch ./lib/*`, it 
 
 ## Specifying extension watch list
 
-By default, nodemon looks for files with the `.js`, `.coffee`, `.litcoffee`, and `.json` extensions. If you use the `--exec` option and monitor `app.py` nodemon will monitor files with the extension of `.py`. However, you can specify your own list with the `-e` (or `--ext`) switch like so:
+By default, nodemon looks for files with the `.js`, `.coffee`, `.litcoffee`, `.ts`, and `.json` extensions. If you use the `--exec` option and monitor `app.py` nodemon will monitor files with the extension of `.py`. However, you can specify your own list with the `-e` (or `--ext`) switch like so:
 
     nodemon -e js,jade
 

--- a/doc/cli/help.txt
+++ b/doc/cli/help.txt
@@ -22,7 +22,7 @@
 
   Note: if the script is omitted, nodemon will try to read "main" from
   package.json and without a nodemon.json, nodemon will monitor .js, .coffee,
-  and .litcoffee by default.
+  .litcoffee, and .ts by default.
 
   To learn more about nodemon.json config: nodemon --help config
   See also the sample: https://github.com/remy/nodemon/wiki/Sample-nodemon.json

--- a/lib/config/exec.js
+++ b/lib/config/exec.js
@@ -141,7 +141,7 @@ function exec(nodemonOptions, execMap) {
   if (options.exec === 'coffee') {
     // don't override user specified extension tracking
     if (!options.ext) {
-      extension = 'coffee,litcoffee,js,json';
+      extension = 'coffee,litcoffee,js,json,ts';
     }
 
     // because windows can't find 'coffee', it needs the real file 'coffee.cmd'


### PR DESCRIPTION
If CoffeeScript files are included by default, it seems reasonable to also include TypeScript files by default.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/remy/nodemon/871)

<!-- Reviewable:end -->
