### PR TITLE
Fix/blessed

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -37,7 +37,7 @@ function run(options) {
   var stdio = ['pipe', 'pipe', 'pipe'];
 
   if (config.options.stdout) {
-    stdio = ['inherit', process.stdout, process.stderr];
+    stdio = [process.send ? 'pipe' : 'inherit', process.stdout, process.stderr];
   }
 
   var sh = 'sh';

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -39,7 +39,7 @@ function run(options) {
   if (config.options.stdout) {
     stdio = [process.send || config.required ? 'pipe' : 'inherit',
              process.stdout,
-             process.stderr];
+             process.stderr,];
   }
 
   var sh = 'sh';

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -37,7 +37,7 @@ function run(options) {
   var stdio = ['pipe', 'pipe', 'pipe'];
 
   if (config.options.stdout) {
-    stdio = [process.send ? 'pipe' : 'inherit', process.stdout, process.stderr];
+    stdio = [process.send || config.required ? 'pipe' : 'inherit', process.stdout, process.stderr];
   }
 
   var sh = 'sh';

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -37,7 +37,9 @@ function run(options) {
   var stdio = ['pipe', 'pipe', 'pipe'];
 
   if (config.options.stdout) {
-    stdio = [process.send || config.required ? 'pipe' : 'inherit', process.stdout, process.stderr];
+    stdio = [process.send || config.required ? 'pipe' : 'inherit',
+             process.stdout,
+             process.stderr];
   }
 
   var sh = 'sh';

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -37,7 +37,7 @@ function run(options) {
   var stdio = ['pipe', 'pipe', 'pipe'];
 
   if (config.options.stdout) {
-    stdio = ['pipe', process.stdout, process.stderr];
+    stdio = ['inherit', process.stdout, process.stderr];
   }
 
   var sh = 'sh';
@@ -227,7 +227,8 @@ function run(options) {
   // connect stdin to the child process (options.stdin is on by default)
   if (options.stdin) {
     process.stdin.resume();
-    process.stdin.setEncoding('utf8');
+    // FIXME decide whether or not we need to decide the encoding
+    // process.stdin.setEncoding('utf8');
     process.stdin.pipe(child.stdin);
 
     bus.once('exit', function () {


### PR DESCRIPTION
Fixes #890
Ref FormidableLabs/webpack-dashboard#16

The library blessed inside of the webpack-dashboard does some funky stuff with std streams and the expectation of the encoding. I'm not 100% sure of this change, I've got to see all the tests, but this tweak moves to inherit the child's stdin and doesn't purposely encode the stdin stream as utf8 (which, I don't recall exactly why I did this in the first place…though I'm fairly sure it was another issue somewhere else in nodemon).

Also, only use `stdin:inherit` when we're not forked (which is generally when we're testing).