### PR TITLE
Fixes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ nodemon does **not** require *any* changes to your code or method of development
 
 # Installation
 
-Either through forking or by using [npm](http://npmjs.org) (the recommended way):
+Either through cloning with git or by using [npm](http://npmjs.org) (the recommended way):
 
     npm install -g nodemon
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Patterns can also be ignored (but be sure to quote the arguments):
 
     nodemon --ignore 'lib/*.js'
 
-Note that by default, nodemon will ignore the `.git`, `node_modules`, `bower_components` and `.sass-cache` directories and *add* your ignored patterns to the list. If you want to indeed watch a directory like `node_modules`, you need to [override the underlying default ignore rules](https://github.com/remy/nodemon/blob/master/faq.md#overriding-the-underlying-default-ignore-rules).
+Note that by default, nodemon will ignore the `.git`, `node_modules`, `bower_components`, `.nyc_output`, `coverage` and `.sass-cache` directories and *add* your ignored patterns to the list. If you want to indeed watch a directory like `node_modules`, you need to [override the underlying default ignore rules](https://github.com/remy/nodemon/blob/master/faq.md#overriding-the-underlying-default-ignore-rules).
 
 ## Application isn't restarting
 


### PR DESCRIPTION
It says "install by forking" but that doesn't make sense - I assume it means cloning.

Add missing ignores `.nyc_output` and `coverage`, which seem to come from here: https://github.com/novemberborn/ignore-by-default/blob/master/index.js

The coverage one bit me because I have a file called coverage.js that is not causing the server to be reloaded when I save it. I think that is related to https://github.com/remy/nodemon/issues/916.