### PR TITLE
feat: change ignore rules to match whole name

### DIFF
--- a/lib/rules/add.js
+++ b/lib/rules/add.js
@@ -82,6 +82,9 @@ function add(rules, which, rule) {
       return rule.replace(reEscapeChars, '\\$&')
                  .replace(reAsterisk, '.*');
     }).join('|');
+    // Only match if a '\', '/' or nothing comes before item
+    // Additionally only match if a '\', '/' or nothing comes after the item
+    re = '(\\/|\\\\|^)(' + re + ')($|\\/|\\\\)';
 
     // used for the directory matching
     rules[which].re = new RegExp(re);


### PR DESCRIPTION
Previously ignore rules would be fuzzy compared (a rule of '.git' would match 'myproject.git') and have unintended consequences.
Fixes #916
