### PR TITLE
:bug: Fix update-notifier race condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "ps-tree": "^1.0.1",
     "touch": "1.0.0",
     "undefsafe": "0.0.3",
-    "update-notifier": "0.5.0"
+    "update-notifier": "1.0.2"
   }
 }


### PR DESCRIPTION
There's a race condition issue on `write-file-atomic` (see https://github.com/npm/write-file-atomic/issues/10) which is fixed in `write-file-atomic@1.2.0`.

`nodemon` uses `update-notifier` which depends on `configstore` which itself depends on `write-file-atomic`. The latest `update-notifier@1.0.2` uses the fixed version of `write-file-atomic`.

This fixes the #901 issue (`EPERM: operation not permitted, rename` on Windows).