### PR TITLE
Exit with code 1 on crash if --exitcrash

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -156,7 +156,7 @@ function run(options) {
       if (options.exitcrash) {
         utils.log.fail('app crashed');
         if (!config.required) {
-          process.exit(0);
+          process.exit(1);
         }
       } else {
         utils.log.fail('app crashed - waiting for file changes before' +


### PR DESCRIPTION
I'm using nodemon in a docker container with a restart policy configured to restart the container in case it crashes. If my app crashes, nodemon exits with code 0 and thus docker assumes it was a graceful exit, so it does not restart my container. I don't see the harm in changing the exit code here to reflect an unexpected termination, given that this path is only exercised in the event of a crash.