### PR TITLE
fix: avoid changing parent's current working directory

### DIFF
--- a/lib/cli/parse.js
+++ b/lib/cli/parse.js
@@ -196,11 +196,6 @@ function nodemonOption(options, arg, eatNext) {
 
   if (arg === '--cwd') {
     options.cwd = eatNext();
-
-    // go ahead and change directory. This is primarily for nodemon tools like
-    // grunt-nodemon - we're doing this early because it will affect where the
-    // user script is searched for.
-    process.chdir(path.resolve(options.cwd));
   } else {
 
     // this means we didn't match

--- a/lib/config/exec.js
+++ b/lib/config/exec.js
@@ -9,13 +9,13 @@ module.exports = exec;
  *
  * @return {Object} exec & script if found
  */
-function execFromPackage() {
+function execFromPackage(cwd) {
   // doing a try/catch because we can't use the path.exist callback pattern
   // or we could, but the code would get messy, so this will do exactly
   // what we're after - if the file doesn't exist, it'll throw.
   try {
     // note: this isn't nodemon's package, it's the user's cwd package
-    var pkg = require(path.join(process.cwd(), 'package.json'));
+    var pkg = require(path.join(cwd || process.cwd(), 'package.json'));
     if (pkg.main !== undefined) {
       // no app found to run - so give them a tip and get the feck out
       return { exec: null, script: pkg.main };
@@ -55,7 +55,7 @@ function exec(nodemonOptions, execMap) {
   // should be parsed first, then the user options (via nodemon.json) then
   // finally default down to pot shots at the directory via package.json
   if (!nodemonOptions.exec && !nodemonOptions.script) {
-    var found = execFromPackage();
+    var found = execFromPackage(nodemonOptions.cwd);
     if (found !== null) {
       if (found.exec) {
         nodemonOptions.exec = found.exec;

--- a/lib/config/load.js
+++ b/lib/config/load.js
@@ -26,7 +26,8 @@ function load(settings, options, config, callback) {
     if (settings.configFile) {
       options.configFile = path.resolve(settings.configFile);
     }
-    loadFile(options, config, process.cwd(), function (options) {
+    var cwd = path.resolve(settings.cwd || process.cwd());
+    loadFile(options, config, cwd, function (options) {
       // Then merge over with the user settings (parsed from the cli).
       // Note that merge protects and favours existing values over new values,
       // and thus command line arguments get priority
@@ -51,6 +52,12 @@ function load(settings, options, config, callback) {
         options.ignore = defaults.ignore.concat(options.ignore);
       }
 
+      // ensure we use the full path to the working dir
+      if (!options.cwd) {
+        options.cwd = cwd;
+      } else {
+        options.cwd = path.resolve(options.cwd);
+      }
 
       // add in any missing defaults
       options = utils.merge(options, defaults);
@@ -64,6 +71,7 @@ function load(settings, options, config, callback) {
         nodeArgs: options.nodeArgs,
         ext: options.ext,
         env: options.env,
+        cwd: options.cwd,
       }, options.execMap);
 
       // clean up values that we don't need at the top level

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -65,9 +65,13 @@ function run(options) {
 
   if (utils.version.major === 0 && utils.version.minor < 8) {
     // use the old spawn args :-\
+    spawnArgs.push({
+      cwd: options.cwd,
+    });
   } else {
     spawnArgs.push({
       env: utils.merge(options.execOptions.env, process.env),
+      cwd: options.cwd,
       stdio: stdio,
     });
   }

--- a/lib/nodemon.js
+++ b/lib/nodemon.js
@@ -53,17 +53,6 @@ function nodemon(settings) {
     return;
   }
 
-  // nodemon tools like grunt-nodemon. This affects where
-  // the script is being run from, and will affect where
-  // nodemon looks for the nodemon.json files
-  if (settings.cwd) {
-    // this is protection to make sure we haven't dont the chdir already...
-    // say like in cli/parse.js (which is where we do this once already!)
-    if (process.cwd() !== path.resolve(config.system.cwd, settings.cwd)) {
-      process.chdir(settings.cwd);
-    }
-  }
-
   config.load(settings, function (config) {
     if (!config.options.dump && !config.options.execOptions.script &&
       config.options.execOptions.exec === 'node') {
@@ -81,7 +70,7 @@ function nodemon(settings) {
     utils.log.info(version.pinned);
 
     if (config.options.cwd) {
-      utils.log.detail('process root: ' + process.cwd());
+      utils.log.detail('process root: ' + config.options.cwd);
     }
 
     config.loaded.forEach(function (filename) {

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -32,10 +32,13 @@ module.exports = function spawn(command, config, eventArgs) {
     var env = merge(process.env, { FILENAME: eventArgs[0] });
     child = _spawn(sh, [shFlag, args], {
       env: merge(config.options.execOptions.env, env),
+      cwd: config.options.cwd,
       stdio: stdio,
     });
   } else {
-    child = spawn(sh, args);
+    child = spawn(sh, args, {
+      cwd: config.options.cwd,
+    });
   }
 
   if (config.required) {


### PR DESCRIPTION
Currently, if you use nodemon as a library with the `cwd` argument, nodemon will change the current working directory of the parent process. In many cases, this is undesirable. This change uses the `cwd` argument to `child_process.spawn` instead.

Thoughts / comments / requests welcome.