### PR TITLE
Update update-notifier dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "ps-tree": "^1.0.1",
     "touch": "1.0.0",
     "undefsafe": "0.0.3",
-    "update-notifier": "0.5.0"
+    "update-notifier": "~1.0.3"
   }
 }


### PR DESCRIPTION
This is useful because update-notifier 0.5 uses latest-version 1.x which has [return statements outside functions](https://github.com/sindresorhus/latest-version/blob/v1.0.0/cli.js#L24) which prevents it from being used with Babel (it is a syntax error).