### PR TITLE
Fix executable path handling under windows

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -12,6 +12,7 @@ var noop = function () {};
 var restart = null;
 var psTree = require('ps-tree');
 var hasPS = true;
+var path = require('path');
 
 // discover if the OS has `ps`, and therefore can use psTree
 exec('ps', function (error) {
@@ -52,11 +53,23 @@ function run(options) {
 
   var executable = cmd.executable;
 
-  // special logic for windows, as spaces in the paths need the path fragment
-  // quoted, so it reads: c:\"Program Files"\nodejs\node.exe
-  if (utils.isWindows && executable.indexOf(' ') !== -1) {
-    var re = /\\((\w+\s+)+\w+)(?=([\\\.]))(?=([^"]*"[^"]*")*[^"]*$)/g;
-    executable = executable.replace(re, '\\"$1"');
+  if (utils.isWindows) {
+    // under windows if the executable path contains a forward slash, that will
+    // fail with cmd.exe, so we need to normalize it
+    if (executable.indexOf('/') !== -1) {
+      executable = path.normalize(executable);
+    }
+
+    // if the executable path contains a space the whole string must be quoted
+    // to get windows treat it as 1 argument for cmd.exe
+    if (executable.indexOf(' ') !== -1 && executable[0] !== '\"'
+        && executable[executable.length - 1] !== '\"') {
+      // remove all quotes from executable (possible backward compat hacks)
+      executable = executable.replace (/\"/g, '');
+
+      // add quotes to beginning and end of executable
+      executable = '\"' + executable + '\"';
+    }
   }
 
   var args = runCmd ? utils.stringify(executable, cmd.args) : ':';


### PR DESCRIPTION
- If the user configured a *nix compatible npm script where the path contained a forward slash, that failed under windows, since cmd.exe treated that as a command line argument.
- The quote handling was not 100% correct under windows, the whole path needs to be quoted, not just the segments it is also modified.