### PR TITLE
process.exit() hint

### DIFF
--- a/doc/requireable.md
+++ b/doc/requireable.md
@@ -16,6 +16,7 @@ nodemon.on('start', function () {
   console.log('App has started');
 }).on('quit', function () {
   console.log('App has quit');
+  process.exit();
 }).on('restart', function (files) {
   console.log('App restarted due to: ', files);
 });


### PR DESCRIPTION
I kept getting this annoying problem after following this tutorial which is best described in this gulp thread. https://github.com/JacksonGariety/gulp-nodemon/issues/77. I'm not using gulp but the problem is the same. By adding process.exit() on nodemon quit the problem goes away smoothly.

Maybe add this process.exit() hint in the docs here?