### PR TITLE
Fix: nodemon can't read config files encoded with BOM e.g. UTF-8-BOM #1031

### DIFF
--- a/lib/config/load.js
+++ b/lib/config/load.js
@@ -177,7 +177,7 @@ function loadFile(options, config, dir, ready) {
     var settings = {};
 
     try {
-      settings = JSON.parse(data);
+      settings = JSON.parse(data.toString('utf8').replace(/^\uFEFF/, ''));
       config.loaded.push(filename);
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
Fix: nodemon can't read config files encoded with BOM e.g. UTF-8-BOM #1031