### PR TITLE
fix: catch module.parent.filename === undefined

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -16,7 +16,11 @@ var utils = module.exports = {
   isLinux: process.platform === 'linux',
   isRequired: (function () {
     var p = module.parent;
-    while (p) {
+    while (p) { 
+      // in electron.js engine it happens
+      if (p.filename === undefined) {
+        return true;
+      }
       if (p.filename.indexOf('bin' + path.sep + 'nodemon.js') !== -1) {
         return false;
       }


### PR DESCRIPTION
It happened with electron.js. Maybe some wrapper module has a native nature