### PR TITLE
Add envvar (NODEMON_PROCESS_STAGE) indicating first run or subsequent runs

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -93,6 +93,12 @@ Say you did want to watch the `node_modules` directory. You have to override the
 
 Now when ignoring `public`, the ignore rule results in `['.git', 'public']`, and nodemon will restart on `node_modules` changes.
 
+## How do I check from inside my script that it's running on nodemon?
+
+nodemon injects a single additional environment variable into the process: `NODEMON_PROCESS_STAGE`. Its value is `'1'` if nodemon has not restarted your process yet, and becomes `'2'` after subsequent restarts.
+
+If you have any initialization that you would like to do only when running nodemon and only one time (e.g. printing some help information to the terminal), you can do so by checking if `NODEMON_PROCESS_STAGE` equals `'1'`.
+
 ## nodemon doesn't work with fedora
 
 Fedora is looking for `nodejs` rather than `node` which is the binary that nodemon kicks off.

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -13,6 +13,12 @@ var restart = null;
 var psTree = require('ps-tree');
 var hasPS = true;
 
+// Whether the process has been started once before.
+// 0 = initial state
+// 1 = first run
+// 2 = subsequent runs (restarts after change)
+var processStage = 0;
+
 // discover if the OS has `ps`, and therefore can use psTree
 exec('ps', function (error) {
   if (error) {
@@ -63,11 +69,16 @@ function run(options) {
   var spawnArgs = [sh, [shFlag, args]];
   debug('spawning', args);
 
+  // Increment processStage to keep track of how many times we've restarted.
+  processStage = processStage < 2 ? processStage + 1 : processStage;
+
   if (utils.version.major === 0 && utils.version.minor < 8) {
     // use the old spawn args :-\
   } else {
     spawnArgs.push({
-      env: utils.merge(options.execOptions.env, process.env),
+      env: utils.merge(options.execOptions.env, process.env, {
+        NODEMON_PROCESS_STAGE: processStage
+      }),
       stdio: stdio,
     });
   }

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -69,7 +69,7 @@ function run(options) {
   var spawnArgs = [sh, [shFlag, args]];
   debug('spawning', args);
 
-  // Increment processStage to keep track of how many times we've restarted.
+  // Increment processStage to keep track of whether we have restarted yet.
   processStage = processStage < 2 ? processStage + 1 : processStage;
 
   if (utils.version.major === 0 && utils.version.minor < 8) {

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -77,7 +77,7 @@ function run(options) {
   } else {
     spawnArgs.push({
       env: utils.merge(options.execOptions.env, process.env, {
-        NODEMON_PROCESS_STAGE: processStage
+        NODEMON_PROCESS_STAGE: processStage,
       }),
       stdio: stdio,
     });

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -75,10 +75,10 @@ function run(options) {
   if (utils.version.major === 0 && utils.version.minor < 8) {
     // use the old spawn args :-\
   } else {
+    // Inject the process stage envvar.
+    options.execOptions.env.NODEMON_PROCESS_STAGE = processStage;
     spawnArgs.push({
-      env: utils.merge(options.execOptions.env, process.env, {
-        NODEMON_PROCESS_STAGE: processStage,
-      }),
+      env: utils.merge(options.execOptions.env, process.env),
       stdio: stdio,
     });
   }

--- a/test/events/stage.test.js
+++ b/test/events/stage.test.js
@@ -17,7 +17,7 @@ describe('when nodemon restarts one time or more', function () {
     }).emit('quit');
   });
 
-  it('should pass a NODEMON_PROCESS_STAGE value of 2', function (done) {
+  it('should pass a NODEMON_PROCESS_STAGE value of 1 on first boot and 2 on subsequent boots', function (done) {
     var plan = new utils.Plan(3, function () {
       nodemon.reset(done);
     });

--- a/test/events/stage.test.js
+++ b/test/events/stage.test.js
@@ -1,0 +1,54 @@
+'use strict';
+/*global describe:true, it: true, after: true */
+var nodemon = require('../../lib/'),
+    path = require('path'),
+    touch = require('touch'),
+    utils = require('../utils'),
+    assert = require('assert');
+
+var showStage = path.resolve('test/fixtures/stage.js');
+
+describe('when nodemon restarts one time or more', function () {
+  after(function (done) {
+    // clean up just in case.
+    nodemon.once('exit', function () {
+      nodemon.reset();
+      done();
+    }).emit('quit');
+  });
+
+  it('should pass a NODEMON_PROCESS_STAGE value of 2', function (done) {
+    var plan = new utils.Plan(3, function () {
+      nodemon.reset(done);
+    });
+
+    var restarts = 0;
+
+    nodemon({
+      script: showStage,
+      verbose: true,
+      stdout: false,
+      noReset: true,
+      ext: 'js',
+      env: {
+        USER: 'nodemon',
+      },
+    })
+    .on('stdout', function (data) {
+      if (restarts === 0) {
+        plan.assert(data.toString().trim() === '1', 'NODEMON_PROCESS_STAGE is \'1\' on first boot');
+      }
+      else {
+        plan.assert(data.toString().trim() === '2', 'NODEMON_PROCESS_STAGE is \'2\' on subsequent boots');
+      }
+    })
+    .on('exit', function () {
+      if (++restarts > 2) {
+        return;
+      }
+      setTimeout(function () {
+        touch.sync(showStage);
+      }, 100);
+    });
+  });
+});

--- a/test/fixtures/stage.js
+++ b/test/fixtures/stage.js
@@ -1,0 +1,1 @@
+console.log(process.env.NODEMON_PROCESS_STAGE);


### PR DESCRIPTION
This adds a `NODEMON_PROCESS_STAGE` environment variable to the spawned process that is 1 during the initial run, and 2 during subsequent runs. This allows the user to skip certain initialization routines that are not necessary on restart.

Fixes #1075. Given that the project is inactive I doubt this will get merged, but it's here for posterity and in case someone else needs this. I'll probably publish my fork on NPM under another name.