### PR TITLE
chore: touch@3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lodash.defaults": "^3.1.2",
     "minimatch": "^3.0.0",
     "ps-tree": "^1.0.1",
-    "touch": "1.0.0",
+    "touch": "^3.1.0",
     "undefsafe": "0.0.3",
     "update-notifier": "0.5.0"
   }


### PR DESCRIPTION
Old versions of touch install a binary that may conflicts with system, like [here](https://github.com/Homebrew/brew/issues/2891).