### PR TITLE
fix: read config file before defaulting script parameter

### DIFF
--- a/lib/cli/parse.js
+++ b/lib/cli/parse.js
@@ -85,17 +85,6 @@ function parse(argv) {
     }
   }
 
-  if (script === null && !nodemonOptions.exec) {
-    var found = findAppScript();
-    if (found !== null) {
-      if (found.exec) {
-        nodemonOptions.exec = found.exec;
-      }
-      script = found.script;
-      nodemonOptions.scriptPosition = args.length;
-    }
-  }
-
   nodemonOptions.script = script;
   nodemonOptions.args = args;
 
@@ -210,16 +199,6 @@ function nodemonOption(options, arg, eatNext) {
     // this means we didn't match
     return false;
   }
-}
-
-function findAppScript() {
-  // nodemon has been run alone, so try to read the package file
-  // or try to read the index.js file
-  if (existsSync('./index.js')) {
-    return { exec: null, script: 'index.js' };
-  }
-
-  return null;
 }
 
 /**

--- a/lib/config/load.js
+++ b/lib/config/load.js
@@ -10,6 +10,16 @@ var defaults = require('./defaults');
 
 module.exports = load;
 
+var existsSync = fs.existsSync || path.existsSync;
+
+function findAppScript() {
+  // nodemon has been run alone, so try to read the package file
+  // or try to read the index.js file
+  if (existsSync('./index.js')) {
+    return 'index.js';
+  }
+}
+
 /**
  * Load the nodemon config, first reading the global root/nodemon.json, then
  * the local nodemon.json to the exec and then overwritting using any user
@@ -54,6 +64,13 @@ function load(settings, options, config, callback) {
 
       // add in any missing defaults
       options = utils.merge(options, defaults);
+
+      if (!options.script && !options.exec) {
+        var found = findAppScript();
+        if (found) {
+          options.script = found;
+        }
+      }
 
       // work out the execOptions based on the final config we have
       options.execOptions = exec({


### PR DESCRIPTION
If I have a nodemon.json config file with an `exec` property, then this is automatically appended with ` index.js` when running `nodemon` standalone.

I would expect this to be equivalent to running `nodemon --exec "my cmd"` - that is providing an `exec` prevents defaulting of `script` to index.js.

To resolve, move the code which defaults the `script` property when `exec` is undefined to after the config files have been read, so that the behaviour is the same irrespective of whether properties are set in CLI flags or in nodemon.json.