### PR TITLE
fix: Add support for multi-level file extensions

### DIFF
--- a/lib/config/exec.js
+++ b/lib/config/exec.js
@@ -155,7 +155,9 @@ function exec(nodemonOptions, execMap) {
   // BIG NOTE: user can't do this: nodemon -e *.js
   // because the terminal will automatically expand the glob against
   // the file system :(
-  extension = (extension.match(/[^,.\s]+/g) || []).join(',');
+  extension = (extension.match(/[^,*\s]+/g) || [])
+    .map(ext => ext.replace(/^\./, ''))
+    .join(',');
 
   options.ext = extension;
 

--- a/test/cli/exec.test.js
+++ b/test/cli/exec.test.js
@@ -121,4 +121,19 @@ describe('nodemon exec', function () {
     var res = exec(options);
     assert(res.ext === 'ζ', 'exec did not bail');
   });
+
+  it('should support multi-level file extensions', function () {
+    var options = exec({ ext: '.ts.d,js md' });
+
+    assert(options.ext.indexOf('ts.d') !== -1);
+    assert(options.ext.indexOf('js') !== -1);
+    assert(options.ext.indexOf('md') !== -1);
+  });
+
+  it('should support single-level file extensions', function () {
+    var options = exec({ ext: '.js, jade' });
+
+    assert(options.ext.indexOf('js') !== -1);
+    assert(options.ext.indexOf('jade') !== -1);
+  });
 });


### PR DESCRIPTION
Fixes #810 

Allows the ability to watch file extensions such as `ts.d` without it triggering when a `.ts` or `.d` file is changed.