### PR TITLE
fix: Clarified that "mounted drives" refers to mounted network drives in Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Note that by default, nodemon will ignore the `.git`, `node_modules`, `bower_com
 
 ## Application isn't restarting
 
-In some networked environments (such as a container running nodemon reading across a mounted drive), you will need to use the `legacyWatch: true` which enables Chokidar's polling.
+In some networked environments (such as a container running nodemon reading across a drive mounted over the network), you will need to use the `legacyWatch: true` which enables Chokidar's polling.
 
 Via the CLI, use either `--legacy-watch` or `-L` for short:
 


### PR DESCRIPTION
Changed the "Application isn't restarting" to clarify that mounted drives are, in fact, mounted network drives in this case (since drives that are mounted do not necessarily have to be via the network).