### PR TITLE
Use child_process.fork when running node scripts...

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -2,8 +2,9 @@ var debug = require('debug')('nodemon');
 var utils = require('../utils');
 var bus = utils.bus;
 var childProcess = require('child_process');
-var spawn = childProcess.spawn;
 var exec = childProcess.exec;
+var fork = childProcess.fork;
+var spawn = childProcess.spawn;
 var watch = require('./watch').watch;
 var config = require('../config');
 var child = null; // the actual child process we spawn
@@ -71,6 +72,7 @@ function run(options) {
 
   var args = runCmd ? utils.stringify(executable, cmd.args) : ':';
   var spawnArgs = [sh, [shFlag, args]];
+
   debug('spawning', args);
 
   if (utils.version.major === 0 && utils.version.minor < 8) {
@@ -82,7 +84,14 @@ function run(options) {
     });
   }
 
-  child = spawn.apply(null, spawnArgs);
+  if (executable === 'node') {
+    var forkArgs = cmd.args.slice(1);
+    child = fork(options.execOptions.script, forkArgs, {
+      env: utils.merge(options.execOptions.env, process.env),
+    });
+  } else {
+    child = spawn.apply(null, spawnArgs);
+  }
 
   if (config.required) {
     var emit = {


### PR DESCRIPTION
* Handles cleanup of node child processes gracefully.
* Doesn't pass tests, but I'm too lazy to go into this any further.
* Regardless, `child_process.fork` is the correct way to handle node child processes.