### PR TITLE
fix #1133 Support for .mjs es6 modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Don't use unix globbing to pass multiple directories, e.g `--watch ./lib/*`, it 
 
 ## Specifying extension watch list
 
-By default, nodemon looks for files with the `.js`, `.coffee`, `.litcoffee`, and `.json` extensions. If you use the `--exec` option and monitor `app.py` nodemon will monitor files with the extension of `.py`. However, you can specify your own list with the `-e` (or `--ext`) switch like so:
+By default, nodemon looks for files with the `.js`, `.mjs`, `.coffee`, `.litcoffee`, and `.json` extensions. If you use the `--exec` option and monitor `app.py` nodemon will monitor files with the extension of `.py`. However, you can specify your own list with the `-e` (or `--ext`) switch like so:
 
     nodemon -e js,jade
 

--- a/doc/cli/help.txt
+++ b/doc/cli/help.txt
@@ -22,7 +22,7 @@
   -- <your args> ........... to tell nodemon stop slurping arguments.
 
   Note: if the script is omitted, nodemon will try to read "main" from
-  package.json and without a nodemon.json, nodemon will monitor .js, .coffee,
+  package.json and without a nodemon.json, nodemon will monitor .js, .mjs, .coffee,
   and .litcoffee by default.
 
   To learn more about nodemon.json config: nodemon --help config

--- a/lib/config/exec.js
+++ b/lib/config/exec.js
@@ -141,7 +141,7 @@ function exec(nodemonOptions, execMap) {
   if (options.exec === 'coffee') {
     // don't override user specified extension tracking
     if (!options.ext) {
-      extension = 'coffee,litcoffee,js,json';
+      extension = 'coffee,litcoffee,js,json,mjs';
     }
 
     // because windows can't find 'coffee', it needs the real file 'coffee.cmd'


### PR DESCRIPTION
Updated code to add .mjs extension, per discussion in #1133.

Unfortunately was unable to run updated code or tests on my Node 8.7.0 installation due to multiple issues with 'npm install'.  Searched the issues list and there were many other people having trouble here too.  I tried the various workarounds suggested in those issues and none of them resolved the issue for me.  The one I couldn't get past was, "404 Not Found: ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz".

I didn't see test cases around the other default file extensions, so I didn't extend the tests to add extension tests.