### PR TITLE
feat: watch script regardless of extension

### DIFF
--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -24,7 +24,6 @@ function resetWatchers() {
   watchers = [];
 }
 
-
 function watch() {
   if (watchers.length) {
     debug('early exit on watch, still watching (%s)', watchers.length);
@@ -140,6 +139,22 @@ function filterAndRestart(files) {
       config.options.monitor,
       undefsafe(config, 'options.execOptions.ext')
     );
+
+    // if there's no matches, then test to see if the changed file is the
+    // running script, if so, let's allow a restart
+    const script = path.resolve(config.options.execOptions.script);
+    if (matched.result.length === 0 && script) {
+      const length = script.length;
+      files.find(file => {
+        if (file.substr(-length, length) === script) {
+          matched = {
+            result: [ file ],
+            total: 1,
+          }
+          return true;
+        }
+      })
+    }
 
     utils.log.detail('changes after filters (before/after): ' +
       [files.length, matched.result.length].join('/'));


### PR DESCRIPTION
Fixes the issue where express is a js based project, but the executable
is `www`, so it misses on the match. So now nodemon will watch for
matching extensions but *also* the script the user gave.

Fixes #461

Note that this can't handle the situation where npm is used to run `node
./bin/www` as nodemon can't split out a package script command.