### PR TITLE
feat: support wildcard extension matching

### DIFF
--- a/lib/config/exec.js
+++ b/lib/config/exec.js
@@ -97,7 +97,11 @@ function exec(nodemonOptions, execMap) {
   var script = path.basename(options.script || '');
 
   var scriptExt = path.extname(script).slice(1);
-  var extension = options.ext || (scriptExt ? scriptExt + ',json' : 'js,json');
+
+  var extension = options.ext !== undefined ?
+      options.ext :
+      (scriptExt ? scriptExt + ',json' : 'js,json');
+
   var execDefined = !!options.exec;
 
   // allows the user to simplify cli usage:
@@ -164,7 +168,7 @@ function exec(nodemonOptions, execMap) {
 
   if (options.exec === 'coffee') {
     // don't override user specified extension tracking
-    if (!options.ext) {
+    if (options.ext === undefined) {
       extension = 'coffee,litcoffee,js,json,mjs';
     }
 
@@ -186,8 +190,8 @@ function exec(nodemonOptions, execMap) {
   options.ext = extension;
 
   if (options.script) {
-    options.script = expandScript(options.script, '.' +
-      extension.split(',')[0]);
+    options.script = expandScript(options.script,
+      extension && ('.' + extension.split(',')[0]));
   }
 
   options.env = {};

--- a/lib/nodemon.js
+++ b/lib/nodemon.js
@@ -150,7 +150,7 @@ function nodemon(settings) {
       return rule.slice(0, 1) !== '!' ? rule : false;
     }).filter(Boolean).join(' '));
 
-    utils.log.detail('watching extensions: ' + config.options.execOptions.ext);
+    utils.log.detail('watching extensions: ' + (config.options.execOptions.ext || '(all)'));
 
     if (config.options.dump) {
       utils.log._log('log', '--------------');

--- a/test/cli/exec.test.js
+++ b/test/cli/exec.test.js
@@ -93,6 +93,20 @@ describe('nodemon exec', function () {
     assert(options.ext.indexOf('jade') !== -1, 'pipe separated string');
   });
 
+  it('should support watching all extensions', function () {
+    var options = exec({ script: 'app.js', ext: '' });
+    assert.equal(options.ext, '', 'does not set default extensions when empty extension requested');
+
+    options = exec({ script: 'app.js', ext: '.' });
+    assert.equal(options.ext, '', 'treats `.` as wildcard extension');
+
+    options = exec({ script: 'app.js', ext: '*' });
+    assert.equal(options.ext, '', 'treats `*` as wildcard extension');
+
+    options = exec({ script: 'app.coffee', exec: 'coffee', ext: '' });
+    assert.equal(options.ext, '', 'does not set default extensions when empty extension requested');
+  });
+
   it('should replace {{filename}}', function () {
     var options = exec({ script: 'app.js', exec: 'node {{filename}}.tmp --somethingElse' });
 
@@ -181,6 +195,10 @@ describe('nodemon exec', function () {
   it('should expand app to app.js', function () {
     var options = exec({ script: 'app' });
     var cmd = toCmd(options);
+    assert(cmd.string === 'node app.js', cmd.string);
+
+    options = exec({ script: 'app', ext: '' });
+    cmd = toCmd(options);
     assert(cmd.string === 'node app.js', cmd.string);
   });
 


### PR DESCRIPTION
Add support for `--ext ''`; add tests for `--ext '.'` and `--ext '*'`.

Caveat: does not match extension-less files, see: https://github.com/remy/nodemon/issues/743#issuecomment-352405647.
