### PR TITLE
chore: add .npmrc which explicitly enables package-lock; some minor doc tweaks

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Commit messages
 
-Commit messages must follow the [Angular-style](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format) commit format (but excluding the scope).
+Commit messages must follow the [Angular-style](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits) commit format (but excluding the scope).
 
 i.e:
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ node_js:
   - '6'
   - '4'
 before_install:
-  - if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ]; then echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc; fi
+  - if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ]; then echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> .npmrc; fi
 after_success:
   - npm run semantic-release
 branches:

--- a/faq.md
+++ b/faq.md
@@ -97,11 +97,13 @@ Now when ignoring `public`, the ignore rule results in `['.git', 'public']`, and
 
 Fedora is looking for `nodejs` rather than `node` which is the binary that nodemon kicks off.
 
-The solution is a simple workaround, Linux 101:
+A workaround is to make sure that `node` binary exists in the `PATH`:
 
 ```bash
 sudo ln -s /usr/bin/nodejs /usr/local/bin/node
 ```
+
+Alternatively the `--exec nodejs` option can be used. 
 
 Fedora and Ubuntu pakage node as nodejs, because node.dpkg is
 


### PR DESCRIPTION
I also noticed that `jshint` gives a ton of errors when used with the `.jshintrc` in the repo - is still worth keeping around as it seems it is not used anyways?