### PR TITLE
fix: defined directory watching

### DIFF
--- a/lib/monitor/match.js
+++ b/lib/monitor/match.js
@@ -129,6 +129,7 @@ function match(files, monitor, ext) {
   // sort the rules by highest specificity (based on number of slashes)
   // ignore rules (!) get sorted highest as they take precedent
   // TODO actually check separator rules work on windows
+  const cwd = process.cwd();
   var rules = monitor.sort(function (a, b) {
     var r = b.split(path.sep).length - a.split(path.sep).length;
     var aIsIgnore = a.slice(0, 1) === '!';
@@ -154,8 +155,13 @@ function match(files, monitor, ext) {
     }
 
     if (s.slice(0, 2) === '..') {
-      return path.resolve(process.cwd(), s);
+      return path.resolve(cwd, s);
     }
+
+    if (s.indexOf(cwd) === 0) {
+      return s;
+    }
+
     return '**' + (prefix !== path.sep ? path.sep : '') + s;
   });
 
@@ -172,6 +178,8 @@ function match(files, monitor, ext) {
   }
 
   files.forEach(function (file) {
+    file = path.resolve(cwd, file);
+
     var matched = false;
     for (var i = 0; i < rules.length; i++) {
       if (rules[i].slice(0, 1) === '!') {
@@ -205,6 +213,8 @@ function match(files, monitor, ext) {
           }
           matched = true;
           break;
+        } else {
+          // utils.log.detail('no match: ' + rules[i], file);
         }
       }
     }


### PR DESCRIPTION
Absolute paths being watched meant that they had a `**` added at the start of the `watch` array, which lead to minimatch failing to match the change. So only add the leading glob if it's a relative directory.

Fixes #1181
Fixes #749