### PR TITLE
fix: pass stdin to child process on -I

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -32,9 +32,11 @@ function run(options) {
   var stdio = ['pipe', 'pipe', 'pipe'];
 
   if (config.options.stdout) {
-    stdio = ['pipe',
-      process.stdout,
-      process.stderr,];
+    stdio = ['pipe', process.stdout, process.stderr];
+  }
+
+  if (config.options.stdin === false) {
+    stdio = [process.stdin, process.stdout, process.stderr];
   }
 
   var sh = 'sh';


### PR DESCRIPTION
Fixes #1036 - the no-stdin wasn't passing the process.stdin to the
child.