### PR TITLE
fix: properly ignore defaults, don't match partial

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -11,7 +11,7 @@ module.exports = {
     // compatible with linux, mac and windows, or make the default.js
     // dynamically append the `.cmd` for node based utilities
   },
-  ignoreRoot: ignoreRoot,
+  ignoreRoot: ignoreRoot.map(_ => `**/${_}`),
   watch: ['*.*'],
   stdin: true,
   runOnChangeOnly: false,

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -1,4 +1,4 @@
-var ignoreRoot = require('ignore-by-default').directories()
+var ignoreRoot = require('ignore-by-default').directories();
 
 // default options for config.options
 module.exports = {

--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -32,7 +32,7 @@ function watch() {
   var dirs = [].slice.call(config.dirs);
 
   debugRoot('start watch on: %s', dirs.join(', '));
-  const rootIgnored = config.options.ignore.map(_ => `**/${_}`);
+  const rootIgnored = config.options.ignore;
   debugRoot('ignored', rootIgnored);
 
   var promises = [];

--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -32,19 +32,20 @@ function watch() {
   var dirs = [].slice.call(config.dirs);
 
   debugRoot('start watch on: %s', dirs.join(', '));
-  debugRoot('ignore dirs regex(%s)', config.options.ignore.re);
+  const rootIgnored = config.options.ignore.map(_ => `**/${_}`);
+  debugRoot('ignored', rootIgnored);
 
   var promises = [];
   var watchedFiles = [];
 
   dirs.forEach(function (dir) {
     var promise = new Promise(function (resolve) {
-      var ignored = config.options.ignore.re;
-      var dotFilePattern = /[\/\\]\./;
+      var dotFilePattern = /[/\\]\./;
+      var ignored = Array.from(rootIgnored);
 
       // don't ignore dotfiles if explicitly watched.
       if (!dir.match(dotFilePattern)) {
-        ignored = [ignored, dotFilePattern];
+        ignored.push(dotFilePattern);
       }
 
       var watchOptions = {
@@ -62,7 +63,8 @@ function watch() {
         watchOptions.useFsEvents = false;
       }
 
-      var watcher = chokidar.watch(dir,
+      var watcher = chokidar.watch(
+        dir,
         Object.assign({}, watchOptions, config.watchOptions || {})
       );
 
@@ -89,9 +91,11 @@ function watch() {
 
       watcher.on('error', function (error) {
         if (error.code === 'EINVAL') {
-          utils.log.error('Internal watch failed. Likely cause: too many ' +
+          utils.log.error(
+            'Internal watch failed. Likely cause: too many ' +
             'files being watched (perhaps from the root of a drive?\n' +
-            'See https://github.com/paulmillr/chokidar/issues/229 for details');
+            'See https://github.com/paulmillr/chokidar/issues/229 for details'
+          );
         } else {
           utils.log.error('Internal watch failed: ' + error.message);
           process.exit(1);
@@ -128,10 +132,14 @@ function filterAndRestart(files) {
     }
 
     var cwd = process.cwd();
-    utils.log.detail('files triggering change check: ' +
-      files.map(function (file) {
-        return path.relative(cwd, file);
-      }).join(', '));
+    utils.log.detail(
+      'files triggering change check: ' +
+      files
+        .map(function (file) {
+          return path.relative(cwd, file);
+        })
+        .join(', ')
+    );
 
     var matched = match(
       files,
@@ -150,15 +158,17 @@ function filterAndRestart(files) {
             matched = {
               result: [file],
               total: 1,
-            }
+            };
             return true;
           }
-        })
+        });
       }
     }
 
-    utils.log.detail('changes after filters (before/after): ' +
-      [files.length, matched.result.length].join('/'));
+    utils.log.detail(
+      'changes after filters (before/after): ' +
+      [files.length, matched.result.length].join('/')
+    );
 
     // reset the last check so we're only looking at recently modified files
     config.lastStarted = Date.now();
@@ -176,7 +186,6 @@ function filterAndRestart(files) {
     }
   }
 }
-
 
 function restartBus(matched) {
   utils.log.status('restarting due to changes...');


### PR DESCRIPTION
Changed to passing Chokidar simple strings instead of custom regexp, only had to prefix with `**/` to get it to match the ignore directories properly.

Fixes #916 