### PR TITLE
fix: incorrect count of watch files being reported

### DIFF
--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -108,7 +108,8 @@ function watch() {
   });
 
   return Promise.all(promises).then(function (res) {
-    utils.log.detail(`watching ${watchedFiles.length} file${watchedFiles.length === 1 ? '' : 's'}`);
+    utils.log.detail(`watching ${watchedFiles.length} file${
+      watchedFiles.length === 1 ? '' : 's'}`);
     return watchedFiles;
   });
 }

--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -108,13 +108,7 @@ function watch() {
   });
 
   return Promise.all(promises).then(function (res) {
-    var total = res.reduce(function (acc, curr) {
-      acc += curr;
-      return acc;
-    }, 0);
-
-    var count = total.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-    utils.log.detail('watching ' + count + ' files');
+    utils.log.detail(`watching ${watchedFiles.length} file${watchedFiles.length === 1 ? '' : 's'}`);
     return watchedFiles;
   });
 }


### PR DESCRIPTION
The number of watched files was correct, but showed (incorrectly) a
cumulative total of watched files (i.e. 1 + 2 + 3 + 4 etc).

Fixes #1194