### PR TITLE
fix: don't use fork with `node inspect`

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -78,10 +78,13 @@ function run(options) {
     });
   }
 
+  const firstArg = cmd.args[0] || '';
+
   if (
     // this is a hack to avoid forking if there's a node argument being passed
     // it's a short term fix, and I'm not 100% sure that `fork` is the right way
-    (cmd.args[0] || '').indexOf('-') === -1 &&
+    firstArg.indexOf('-') === -1 &&
+    firstArg !== 'inspect' &&
     executable === 'node' &&
     utils.version.major > 4
   ) {


### PR DESCRIPTION
Fixes: #1191