### PR TITLE
Watch both js and mjs files

### DIFF
--- a/lib/config/exec.js
+++ b/lib/config/exec.js
@@ -113,9 +113,12 @@ function exec(nodemonOptions, execMap) {
 
   var scriptExt = path.extname(script).slice(1);
 
-  var extension = options.ext !== undefined ?
-      options.ext :
-      (scriptExt ? scriptExt + ',json' : 'js,json');
+  var extension = options.ext;
+  if (extension === undefined) {
+    var isJS = scriptExt === 'js' || scriptExt === 'mjs';
+    extension = (isJS || !scriptExt) ? 'js,mjs' : scriptExt;
+    extension += ',json'; // Always watch JSON files
+  }
 
   var execDefined = !!options.exec;
 
@@ -184,7 +187,8 @@ function exec(nodemonOptions, execMap) {
   if (options.exec === 'coffee') {
     // don't override user specified extension tracking
     if (options.ext === undefined) {
-      extension = 'coffee,litcoffee,js,json,mjs';
+      if (extension) { extension += ','; }
+      extension += 'coffee,litcoffee';
     }
 
     // because windows can't find 'coffee', it needs the real file 'coffee.cmd'

--- a/test/cli/exec.test.js
+++ b/test/cli/exec.test.js
@@ -63,7 +63,7 @@ describe('nodemon exec', function () {
     var options = exec({ script: 'index.js' });
     var cmd = toCmd(options);
     assert.equal(options.exec, 'node', 'exec is node');
-    assert.equal(options.ext, 'js,json');
+    assert.equal(options.ext, 'js,mjs,json');
     assert.equal(cmd.string, 'node index.js', cmd.string);
   });
 


### PR DESCRIPTION
- Watch both `js` and `mjs` files if the script is either a `js` or `mjs` file or file with no extension. (For some reason that was before only the case when the main script was a CoffeeScript file xD)
- Some cleanup