### PR TITLE
fix: swallow child.stdin err

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -67,7 +67,6 @@ function run(options) {
 
   var args = runCmd ? utils.stringify(executable, cmd.args) : ':';
   var spawnArgs = [sh, [shFlag, args]];
-  debug('spawning', args);
 
   if (utils.version.major === 0 && utils.version.minor < 8) {
     // use the old spawn args :-\
@@ -95,9 +94,14 @@ function run(options) {
       env: env,
       stdio: stdio,
     });
+    utils.log.detail('forking');
+    debug(forkArgs);
   } else {
+    utils.log.detail('spawning');
     child = spawn.apply(null, spawnArgs);
+    debug(spawnArgs);
   }
+
 
   if (config.required) {
     var emit = {
@@ -257,6 +261,10 @@ function run(options) {
     process.stdin.resume();
     // FIXME decide whether or not we need to decide the encoding
     // process.stdin.setEncoding('utf8');
+
+    // swallow the stdin error if it happens
+    // ref: https://github.com/remy/nodemon/issues/1195
+    child.stdin.on('error', () => {});
     process.stdin.pipe(child.stdin);
 
     bus.once('exit', function () {


### PR DESCRIPTION
This is a weird case where stdin isn't fully connected and throws in
ubuntu 16.04 (replicated in a Docker image).

Fixes #1195