### PR TITLE
 fix: correctly pass ignored rules to chokidar

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -11,7 +11,7 @@ module.exports = {
     // compatible with linux, mac and windows, or make the default.js
     // dynamically append the `.cmd` for node based utilities
   },
-  ignoreRoot: ignoreRoot.map(_ => `**/${_}`),
+  ignoreRoot: ignoreRoot.map(_ => `**/${_}/**`),
   watch: ['*.*'],
   stdin: true,
   runOnChangeOnly: false,

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -80,6 +80,10 @@ config.load = function (settings, ready) {
     bus.emit('config:update', config);
     pinVersion().then(function () {
       ready(config);
+    }).catch(e => {
+      // this doesn't help testing, but does give exposure on syntax errors
+      console.error(e.stack);
+      throw e;
     });
   });
 };

--- a/lib/monitor/match.js
+++ b/lib/monitor/match.js
@@ -89,7 +89,8 @@ function rulesToMonitor(watch, ignore, config) {
     if (rule.slice(-4) !== '**/*' &&
       rule.slice(-1) === '*' &&
       rule.indexOf('*.') === -1) {
-      rule += '*/*';
+
+      if (rule.slice(-2) !== '**') rule += '*/*';
     }
 
 

--- a/lib/monitor/match.js
+++ b/lib/monitor/match.js
@@ -90,7 +90,9 @@ function rulesToMonitor(watch, ignore, config) {
       rule.slice(-1) === '*' &&
       rule.indexOf('*.') === -1) {
 
-      if (rule.slice(-2) !== '**') rule += '*/*';
+      if (rule.slice(-2) !== '**') {
+        rule += '*/*';
+      }
     }
 
 

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -102,7 +102,6 @@ function run(options) {
     debug(spawnArgs);
   }
 
-
   if (config.required) {
     var emit = {
       stdout: function (data) {
@@ -264,7 +263,7 @@ function run(options) {
 
     // swallow the stdin error if it happens
     // ref: https://github.com/remy/nodemon/issues/1195
-    child.stdin.on('error', () => {});
+    child.stdin.on('error', () => { });
     process.stdin.pipe(child.stdin);
 
     bus.once('exit', function () {

--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -49,6 +49,7 @@ function watch() {
       }
 
       var watchOptions = {
+        cwd: process.cwd(), // use cwd for relative path ignore
         ignored: ignored,
         persistent: true,
         usePolling: config.options.legacyWatch || false,

--- a/lib/nodemon.js
+++ b/lib/nodemon.js
@@ -156,7 +156,7 @@ function nodemon(settings) {
       rule = rule.slice(1);
 
       // don't notify of default ignores
-      if (defaults.ignoreRoot.includes(rule)) {
+      if (defaults.ignoreRoot.indexOf(rule) !== -1) {
         return false;
         return rule.slice(3).slice(0, -3);
       }

--- a/lib/nodemon.js
+++ b/lib/nodemon.js
@@ -9,6 +9,7 @@ var bus = utils.bus;
 var help = require('./help');
 var config = require('./config');
 var spawn = require('./spawn');
+const defaults = require('./config/defaults')
 var eventHandlers = {};
 
 // this is fairly dirty, but theoretically sound since it's part of the
@@ -65,6 +66,8 @@ function nodemon(settings) {
     }
   }
 
+  const cwd = process.cwd();
+
   config.load(settings, function (config) {
     if (!config.options.dump && !config.options.execOptions.script &&
       config.options.execOptions.exec === 'node') {
@@ -82,7 +85,7 @@ function nodemon(settings) {
     utils.log.info(version.pinned);
 
     if (config.options.cwd) {
-      utils.log.detail('process root: ' + process.cwd());
+      utils.log.detail('process root: ' + cwd);
     }
 
     config.loaded.forEach(function (filename) {
@@ -145,9 +148,26 @@ function nodemon(settings) {
         restartSignal + ' to ' + process.pid + ' to restart');
     }
 
-    utils.log.detail('ignoring: ' + config.options.monitor.map(function (rule) {
-      return rule.slice(0, 1) === '!' ? rule.slice(1) : false;
-    }).filter(Boolean).join(' '));
+    const ignoring = config.options.monitor.map(function (rule) {
+      if (rule.slice(0, 1) !== '!') {
+        return false;
+      }
+
+      rule = rule.slice(1);
+
+      // don't notify of default ignores
+      if (defaults.ignoreRoot.includes(rule)) {
+        return false;
+        return rule.slice(3).slice(0, -3);
+      }
+
+      if (rule.startsWith(cwd)) {
+        return rule.replace(cwd, '.');
+      }
+
+      return rule;
+    }).filter(Boolean).join(' ');
+    if (ignoring) utils.log.detail('ignoring: ' + ignoring);
 
     utils.log.info('watching: ' + config.options.monitor.map(function (rule) {
       return rule.slice(0, 1) !== '!' ? rule : false;
@@ -160,7 +180,7 @@ function nodemon(settings) {
       utils.log._log('log', 'node: ' + process.version);
       utils.log._log('log', 'nodemon: ' + version.pinned);
       utils.log._log('log', 'command: ' + process.argv.join(' '));
-      utils.log._log('log', 'cwd: ' + process.cwd());
+      utils.log._log('log', 'cwd: ' + cwd);
       utils.log._log('log', ['OS:', process.platform, process.arch].join(' '));
       utils.log._log('log', '--------------');
       utils.log._log('log', util.inspect(config, { depth: null }));


### PR DESCRIPTION
Previous the rules weren't matching fully inside of chokidar, requiring
that, for instance, node_modules is written as **/node_modules/**.

I've also tidied up what's printed in verbose mode, so it doesn't print
default ignores, and doesn't print the full path of an ignored
directory.

This change _also_ fixes notifications from chokidar from user ignored
paths (using the `cwd` argument). This should fix #1202
