### PR TITLE
fix: ignorePermissionErrors in chokidar

### DIFF
--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -49,6 +49,7 @@ function watch() {
       }
 
       var watchOptions = {
+        ignorePermissionErrors: true,
         ignored: ignored,
         persistent: true,
         usePolling: config.options.legacyWatch || false,


### PR DESCRIPTION
Make any permission errors silent, since it the most likely case we don't need them at all.

Fixes: #1213