### PR TITLE
fix: sniff for child.stdout before using it

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -263,8 +263,10 @@ function run(options) {
       if (child.stdout) {
         child.stdout.pipe(process.stdout);
       } else {
-        utils.log.error(`running an unsupported version of node ${process.version}`);
-        utils.log.error('nodemon may not work as expected - please consider upgrading to LTS');
+        utils.log.error('running an unsupported version of node ' +
+          process.version);
+        utils.log.error('nodemon may not work as expected - ' +
+          'please consider upgrading to LTS');
       }
     }
 

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -260,7 +260,12 @@ function run(options) {
       child.stdin.on('error', () => { });
       process.stdin.pipe(child.stdin);
     } else {
-      child.stdout.pipe(process.stdout);
+      if (child.stdout) {
+        child.stdout.pipe(process.stdout);
+      } else {
+        utils.log.error(`running an unsupported version of node ${process.version}`);
+        utils.log.error('nodemon may not work as expected - please consider upgrading to LTS');
+      }
     }
 
     bus.once('exit', function () {


### PR DESCRIPTION
This fixes node@6.0.0, but it's a hack, so I'm going to emit a message
saying that non-LTS is not supported.

Fixes #1234 