### PR TITLE
fix: wrongly normalizing slashes in windows

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -42,36 +42,22 @@ function run(options) {
   var sh = 'sh';
   var shFlag = '-c';
 
+
+  const spawnOptions = {
+    env: utils.merge(options.execOptions.env, process.env),
+    stdio: stdio,
+  }
+
   if (utils.isWindows) {
-    sh = 'cmd';
-    shFlag = '/c';
+    // taken from npm's cli: https://git.io/vNFD4
+    sh = process.env.comspec || 'cmd';
+    shFlag = '/d /s /c';
+    spawnOptions.windowsVerbatimArguments = true;
   }
 
   var executable = cmd.executable;
-
-  if (utils.isWindows) {
-    // under windows if the executable path contains a forward slash, that will
-    // fail with cmd.exe, so we need to normalize it
-    if (executable.indexOf('/') !== -1) {
-      executable = path.normalize(executable);
-    }
-
-    // if the executable path contains a space the whole string must be quoted
-    // to get windows treat it as 1 argument for cmd.exe
-    if (executable.indexOf(' ') !== -1 && executable[0] !== '\"'
-      && executable[executable.length - 1] !== '\"') {
-      // remove all quotes from executable (possible backward compat hacks)
-      executable = executable.replace(/\"/g, '');
-    }
-  }
-
   var args = runCmd ? utils.stringify(executable, cmd.args) : ':';
-  var spawnArgs = [sh, [shFlag, args]];
-
-  spawnArgs.push({
-    env: utils.merge(options.execOptions.env, process.env),
-    stdio: stdio,
-  });
+  var spawnArgs = [sh, [shFlag, args], spawnOptions];
 
   const firstArg = cmd.args[0] || '';
 


### PR DESCRIPTION
This change takes code from npm's cli to change the way the arguments
passed to nodemon are interpreted.

Removes path.normalize and replaces with windowsVerbatimArguments

Fixes #1236