### PR TITLE
feat: feed args to exec when detecting script

### DIFF
--- a/lib/config/load.js
+++ b/lib/config/load.js
@@ -69,6 +69,13 @@ function load(settings, options, config, callback) {
       if (!options.script && !options.exec) {
         var found = findAppScript();
         if (found) {
+          // if the script is found as a result of not being on the command
+          // line, then we move any of the pre double-dash args in execArgs
+          const n = options.scriptPosition || options.args.length;
+          options.execArgs = (options.execArgs || [])
+            .concat(options.args.splice(0, n));
+          options.scriptPosition = null;
+
           options.script = found;
         }
       }

--- a/test/cli/exec.test.js
+++ b/test/cli/exec.test.js
@@ -68,14 +68,14 @@ describe('nodemon exec', function () {
   });
 
   it('should support --debug', function () {
-    var options = exec({ script: 'app.js', nodeArgs: [ '--debug' ]});
+    var options = exec({ script: 'app.js', nodeArgs: ['--debug'] });
     var cmd = toCmd(options);
     assert(cmd.string === 'node --debug app.js', cmd.string);
     assert(options.ext.indexOf('js') !== -1, 'extension watched is .js');
   });
 
   it('should support --debug=XXXX', function () {
-    var options = exec({ script: 'app.js', nodeArgs: [ '--debug=9999' ]});
+    var options = exec({ script: 'app.js', nodeArgs: ['--debug=9999'] });
     var cmd = toCmd(options);
     assert(cmd.string === 'node --debug=9999 app.js', cmd.string);
     assert(options.exec === 'node');
@@ -140,7 +140,7 @@ describe('nodemon exec', function () {
   });
 
   it('should support coffeescript in debug mode', function () {
-    var options = exec({ script: 'app.coffee', nodeArgs: [ '--debug' ] });
+    var options = exec({ script: 'app.coffee', nodeArgs: ['--debug'] });
 
     assert(options.exec.indexOf('coffee') === 0, 'using coffeescript to execute');
     assert(options.execArgs[1].indexOf('--debug') !== -1);
@@ -148,22 +148,22 @@ describe('nodemon exec', function () {
   });
 
   it('should support custom execs', function () {
-    var options = exec({ script: 'app.py', exec: 'python'});
+    var options = exec({ script: 'app.py', exec: 'python' });
 
     assert(options.exec === 'python');
     assert(options.ext.indexOf('py') !== -1);
   });
 
   it('should support custom executables with arguments', function () {
-    var options = exec({ script: 'app.py', exec: 'python --debug'});
+    var options = exec({ script: 'app.py', exec: 'python --debug' });
     var cmd = toCmd(options);
 
     assert(cmd.string === 'python --debug app.py', cmd.string);
     assert(options.ext.indexOf('py') !== -1);
   });
 
-  it('should support an array of exec arguments', function() {
-    var options = exec({script: 'app.js', exec: ['/path to node', '-v']});
+  it('should support an array of exec arguments', function () {
+    var options = exec({ script: 'app.js', exec: ['/path to node', '-v'] });
 
     assert(options.exec === '/path to node', options.exec);
     assert(options.execArgs.length === 1, options.execArgs.length);
@@ -219,4 +219,5 @@ describe('nodemon exec', function () {
     var cmd = toCmd(options);
     assert(cmd.string === 'node index', cmd.string);
   });
+
 });


### PR DESCRIPTION
Fixes #1263

The way it works:

- If the script is detected via index.js from the directory, or from the
package, then all the arguments on the CLI are shifted to execArgs

- If there was a double-dash on the CLI args, then only those before the
double-dash are given to execArgs and the rest remain passed to the
script