### PR TITLE
fix: windows exec resolution

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -48,14 +48,26 @@ function run(options) {
     stdio: stdio,
   }
 
+  var executable = cmd.executable;
+
   if (utils.isWindows) {
+    // if the exec includes a forward slash, reverse it for windows compat
+    // but *only* apply to the first command, and none of the arguments.
+    // ref #1251 and #1236
+    if (executable.indexOf('/') !== -1) {
+      executable = executable.split(' ').map((e, i) => {
+        if (i === 0) {
+          return path.normalize(e);
+        }
+        return e;
+      }).join(' ');
+    }
     // taken from npm's cli: https://git.io/vNFD4
     sh = process.env.comspec || 'cmd';
     shFlag = '/d /s /c';
     spawnOptions.windowsVerbatimArguments = true;
   }
 
-  var executable = cmd.executable;
   var args = runCmd ? utils.stringify(executable, cmd.args) : ':';
   var spawnArgs = [sh, [shFlag, args], spawnOptions];
 


### PR DESCRIPTION
Fixes #1251

Only converts the first exec arg from `/` to `\` rather than all using `path.normalize`