### PR TITLE
feat: try to resolve exec in node_modules/.bin

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -1,4 +1,5 @@
 var debug = require('debug')('nodemon');
+const statSync = require('fs').statSync;
 var utils = require('../utils');
 var bus = utils.bus;
 var childProcess = require('child_process');
@@ -39,12 +40,15 @@ function run(options) {
     stdio = [process.stdin, process.stdout, process.stderr];
   }
 
-  var sh = 'sh';
-  var shFlag = '-c';
+  const sh = 'sh';
+  const shFlag = '-c';
 
+  const binPath = process.cwd() + '/node_modules/.bin';
 
   const spawnOptions = {
-    env: utils.merge(options.execOptions.env, process.env),
+    env: Object.assign({}, options.execOptions.env, process.env, {
+      PATH: binPath + ':' + process.env.PATH,
+    }),
     stdio: stdio,
   }
 
@@ -61,17 +65,26 @@ function run(options) {
 
   const firstArg = cmd.args[0] || '';
 
+  var inBinPath = false;
+  try {
+    inBinPath = statSync(`${binPath}/${executable}`).isFile();
+  } catch (e) {}
+
   // hasStdio allows us to correctly handle stdin piping
   // see: https://git.io/vNtX3
   const hasStdio = utils.satisfies('>= 6.4.0 || < 5');
 
-  if (
+  // forking helps with sub-process handling and tends to clean up better
+  // than spawning, but it should only be used under specific conditions
+  const shouldFork =
     !config.options.spawn &&
-    firstArg.indexOf('-') === -1 && // don't fork if there's a node arg
+    !inBinPath &&
+    firstArg.indexOf('-') === -1 && // don't fork if there's a node exec arg
     firstArg !== 'inspect' && // don't fork it's `inspect` debugger
     executable === 'node' && // only fork if node
     utils.version.major > 4 // only fork if node version > 4
-  ) {
+
+  if (shouldFork) {
     var forkArgs = cmd.args.slice(1);
     var env = utils.merge(options.execOptions.env, process.env);
     stdio.push('ipc');

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -46,7 +46,7 @@ function run(options) {
   const binPath = process.cwd() + '/node_modules/.bin';
 
   const spawnOptions = {
-    env: Object.assign({}, options.execOptions.env, process.env, {
+    env: Object.assign({}, process.env, options.execOptions.env, {
       PATH: binPath + ':' + process.env.PATH,
     }),
     stdio: stdio,

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "pos": "0.4.2",
         "rc": "1.2.2",
         "resolve-from": "3.0.0",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "@semantic-release/commit-analyzer": {
@@ -87,7 +87,7 @@
         "@semantic-release/error": "2.1.0",
         "github": "12.1.0",
         "parse-github-repo-url": "1.4.1",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "travis-deploy-once": "3.0.0"
       },
       "dependencies": {
@@ -885,7 +885,7 @@
         "json-stringify-safe": "5.0.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "split": "1.0.1",
         "through2": "2.0.3"
       },
@@ -2500,7 +2500,7 @@
       "dev": true,
       "requires": {
         "meow": "3.7.0",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "gitconfiglocal": {
@@ -4184,7 +4184,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -4204,7 +4204,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "osenv": "0.1.4",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "validate-npm-package-name": "3.0.0"
       }
     },
@@ -4222,7 +4222,7 @@
         "once": "1.4.0",
         "request": "2.74.0",
         "retry": "0.10.1",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "slide": "1.1.6",
         "ssri": "4.1.6"
       }
@@ -4515,7 +4515,7 @@
         "got": "6.7.1",
         "registry-auth-token": "3.3.1",
         "registry-url": "3.1.0",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "parse-github-repo-url": {
@@ -5004,7 +5004,7 @@
         "p-series": "1.0.0",
         "parse-github-repo-url": "1.4.1",
         "require-relative": "0.8.7",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       },
       "dependencies": {
         "execa": {
@@ -5035,16 +5035,16 @@
       }
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "semver-diff": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "set-blocking": {
@@ -5751,7 +5751,7 @@
       "requires": {
         "chalk": "2.3.0",
         "p-retry": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "travis-ci": "2.1.1"
       }
     },
@@ -5866,9 +5866,9 @@
       "dev": true
     },
     "undefsafe": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.1.tgz",
-      "integrity": "sha1-A7LyoWyUVW4Usu3vMmzWaq+CcHo=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.2.tgz",
+      "integrity": "sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=",
       "requires": {
         "debug": "2.6.9"
       },
@@ -6219,7 +6219,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
         "isexe": "2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
     "ignore-by-default": "^1.0.1",
     "minimatch": "^3.0.4",
     "pstree.remy": "^1.1.0",
-    "semver": "^5.4.1",
+    "semver": "^5.5.0",
     "touch": "^3.1.0",
-    "undefsafe": "^2.0.1",
+    "undefsafe": "^2.0.2",
     "update-notifier": "^2.3.0"
   },
   "version": "0.0.0-development"


### PR DESCRIPTION
Fixes #1268 

This means that instead of 

```bash
nodemon --exec node_modules/.bin/ts-node server.ts
```

You can do:

```bash
nodemon --exec ts-node server.ts
```

And equally supports this technique: https://twitter.com/housecor/status/962347301456015360