### PR TITLE
Fix: watch count regression

### DIFF
--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -39,85 +39,91 @@ function watch() {
   var promises = [];
   var watchedFiles = [];
 
-  dirs.forEach(function (dir) {
-    var promise = new Promise(function (resolve) {
-      var dotFilePattern = /[/\\]\./;
-      var ignored = Array.from(rootIgnored);
+  const promise = new Promise(function (resolve) {
+    const dotFilePattern = /[/\\]\./;
+    var ignored = Array.from(rootIgnored);
+    const addDotFile = dirs.filter(dir => dir.match(dotFilePattern));
 
-      // don't ignore dotfiles if explicitly watched.
-      if (!dir.match(dotFilePattern)) {
-        ignored.push(dotFilePattern);
-      }
+    // don't ignore dotfiles if explicitly watched.
+    if (addDotFile.length === 0) {
+      ignored.push(dotFilePattern);
+    }
 
+    dirs = dirs.map(dir => {
       // if the directory is a file, it somehow causes
       // windows to lose the filename upon change
       if (fs.statSync(dir).isFile()) {
         dir = path.dirname(dir);
       }
 
-      var watchOptions = {
-        ignorePermissionErrors: true,
-        cwd: dir,
-        ignored: ignored,
-        persistent: true,
-        usePolling: config.options.legacyWatch || false,
-        interval: config.options.pollingInterval,
-      };
-
-      if (utils.isWindows) {
-        watchOptions.disableGlobbing = true;
-      }
-
-      if (process.env.TEST) {
-        watchOptions.useFsEvents = false;
-      }
-
-      var watcher = chokidar.watch(
-        dir,
-        Object.assign({}, watchOptions, config.watchOptions || {})
-      );
-
-      watcher.ready = false;
-
-      var total = 0;
-
-      watcher.on('change', filterAndRestart);
-      watcher.on('add', function (file) {
-        if (watcher.ready) {
-          return filterAndRestart(file);
-        }
-
-        watchedFiles.push(file);
-        watchedFiles = Array.from(new Set(watchedFiles)); // ensure no dupes
-        total = watchedFiles.length;
-        bus.emit('watching', file);
-        debug('watching dir: %s', file);
-      });
-      watcher.on('ready', function () {
-        watcher.ready = true;
-        resolve(total);
-        debugRoot('watch is complete');
-      });
-
-      watcher.on('error', function (error) {
-        if (error.code === 'EINVAL') {
-          utils.log.error(
-            'Internal watch failed. Likely cause: too many ' +
-            'files being watched (perhaps from the root of a drive?\n' +
-            'See https://github.com/paulmillr/chokidar/issues/229 for details'
-          );
-        } else {
-          utils.log.error('Internal watch failed: ' + error.message);
-          process.exit(1);
-        }
-      });
-
-      watchers.push(watcher);
+      return dir;
     });
-    promises.push(promise);
+
+    var watchOptions = {
+      ignorePermissionErrors: true,
+      cwd: process.cwd(), // dir,
+      ignored: ignored,
+      persistent: true,
+      usePolling: config.options.legacyWatch || false,
+      interval: config.options.pollingInterval,
+    };
+
+    if (utils.isWindows) {
+      watchOptions.disableGlobbing = true;
+    }
+
+    if (process.env.TEST) {
+      watchOptions.useFsEvents = false;
+    }
+
+    var watcher = chokidar.watch(
+      dirs,
+      Object.assign({}, watchOptions, config.watchOptions || {})
+    );
+
+    watcher.ready = false;
+
+    var total = 0;
+
+    watcher.on('change', filterAndRestart);
+    watcher.on('add', function (file) {
+      if (watcher.ready) {
+        return filterAndRestart(file);
+      }
+
+      watchedFiles.push(file);
+      watchedFiles = Array.from(new Set(watchedFiles)); // ensure no dupes
+      total = watchedFiles.length;
+      bus.emit('watching', file);
+      debug('watching dir: %s', file);
+    });
+    watcher.on('ready', function () {
+      watcher.ready = true;
+      resolve(total);
+      debugRoot('watch is complete');
+    });
+
+    watcher.on('error', function (error) {
+      if (error.code === 'EINVAL') {
+        utils.log.error(
+          'Internal watch failed. Likely cause: too many ' +
+          'files being watched (perhaps from the root of a drive?\n' +
+          'See https://github.com/paulmillr/chokidar/issues/229 for details'
+        );
+      } else {
+        utils.log.error('Internal watch failed: ' + error.message);
+        process.exit(1);
+      }
+    });
+
+    watchers.push(watcher);
   });
 
-  return Promise.all(promises).then(function (res) {
+  return promise.catch(e => {
+    setTimeout(() => {
+      throw e;
+    });
+  }).then(function (res) {
     utils.log.detail(`watching ${watchedFiles.length} file${
       watchedFiles.length === 1 ? '' : 's'}`);
     return watchedFiles;

--- a/package.json
+++ b/package.json
@@ -66,5 +66,5 @@
     "undefsafe": "^2.0.2",
     "update-notifier": "^2.3.0"
   },
-  "version": "1.15.2-alpha.1"
+  "version": "0.0.0-development"
 }


### PR DESCRIPTION
Uses array passed to Chokidar of directories, instead of individually listing them causing overlap of files (and miscount).

Fixes #1283