### PR TITLE
fix: prevent throw when args missing

### DIFF
--- a/lib/config/load.js
+++ b/lib/config/load.js
@@ -69,6 +69,9 @@ function load(settings, options, config, callback) {
       if (!options.script && !options.exec) {
         var found = findAppScript();
         if (found) {
+          if (!options.args) {
+            options.args = [];
+          }
           // if the script is found as a result of not being on the command
           // line, then we move any of the pre double-dash args in execArgs
           const n = options.scriptPosition || options.args.length;


### PR DESCRIPTION
Fixes #1286