### PR TITLE
fix: ignore directories that don't exist yet

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -83,7 +83,7 @@ config.load = function (settings, ready) {
     }).catch(e => {
       // this doesn't help testing, but does give exposure on syntax errors
       console.error(e.stack);
-      throw e;
+      setTimeout(() => { throw e; });
     });
   });
 };

--- a/lib/monitor/match.js
+++ b/lib/monitor/match.js
@@ -73,6 +73,17 @@ function rulesToMonitor(watch, ignore, config) {
       }
     } catch (e) {
       var base = tryBaseDir(dir);
+
+      if (not && base === false) {
+        // this means the rule doesn't exist at all, but we're going to guess
+        // that it's a directory, and we'll filter it anyway. ref #1281
+        rule = dir;
+        if (rule.slice(-1) !== '/') {
+          rule += '/';
+        }
+        rule += '**/*';
+      }
+
       if (!not && base) {
         if (config.dirs.indexOf(base) === -1) {
           config.dirs.push(base);

--- a/lib/monitor/match.js
+++ b/lib/monitor/match.js
@@ -74,7 +74,7 @@ function rulesToMonitor(watch, ignore, config) {
     } catch (e) {
       var base = tryBaseDir(dir);
 
-      if (not && base === false) {
+      if (not && base === false && path.extname(dir) === '') {
         // this means the rule doesn't exist at all, but we're going to guess
         // that it's a directory, and we'll filter it anyway. ref #1281
         rule = dir;


### PR DESCRIPTION
Fixes #1281

Potentially risky change as it assumes the unknown rule is a directory,
but seems like the most sensible default.