### PR TITLE
fix: increase perf of watching large file count

### DIFF
--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -92,12 +92,12 @@ function watch() {
       }
 
       watchedFiles.push(file);
-      watchedFiles = Array.from(new Set(watchedFiles)); // ensure no dupes
-      total = watchedFiles.length;
       bus.emit('watching', file);
       debug('watching dir: %s', file);
     });
     watcher.on('ready', function () {
+      watchedFiles = Array.from(new Set(watchedFiles)); // ensure no dupes
+      total = watchedFiles.length;
       watcher.ready = true;
       resolve(total);
       debugRoot('watch is complete');


### PR DESCRIPTION
Fixes #1317

Originally a new Set was generated upon every individual file (or dir)
watched. This typically doesn't take a long time, but if there's 10,000
files to watch, it's very, very slow. Moving this logic out to the ready
event instead, cuts all the processing time of the watch right down.