### PR TITLE
fix: ignore bare directories fully

### DIFF
--- a/lib/monitor/match.js
+++ b/lib/monitor/match.js
@@ -55,6 +55,7 @@ function rulesToMonitor(watch, ignore, config) {
 
     try {
       var stat = fs.statSync(dir);
+
       if (stat.isDirectory()) {
         rule = dir;
         if (rule.slice(-1) !== '/') {
@@ -67,9 +68,13 @@ function rulesToMonitor(watch, ignore, config) {
           config.dirs.push(dir);
         }
       } else {
-        // ensures we end up in the check that tries to get a base directory
-        // and then adds it to the watch list
-        throw new Error();
+        if (stat.isFile()) {
+          rule = dir;
+        } else {
+          // ensures we end up in the check that tries to get a base directory
+          // and then adds it to the watch list
+          throw new Error();
+        }
       }
     } catch (e) {
       var base = tryBaseDir(dir);

--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -33,7 +33,11 @@ function watch() {
   var dirs = [].slice.call(config.dirs);
 
   debugRoot('start watch on: %s', dirs.join(', '));
-  const rootIgnored = config.options.ignore;
+  // use the compiled monitor list rather than the user provided ignore list
+  // this way we get the benefits of full globs on directories the user provided
+  const rootIgnored = config.options.monitor
+    .filter(_ => _.indexOf('!') === 0)
+    .map(_ => _.slice(1));
   debugRoot('ignored', rootIgnored);
 
   var promises = [];

--- a/test/monitor/match.test.js
+++ b/test/monitor/match.test.js
@@ -361,6 +361,12 @@ describe('validating files that cause restart', function() {
 });
 
 describe('match rule parser', function() {
+  const pwd = process.cwd();
+
+  after(() => {
+    process.chdir(pwd);
+  });
+
   it('should support "--watch ."', function() {
     var config = { watch: '.' };
     var settings = merge(config, defaults);
@@ -410,6 +416,21 @@ describe('match rule parser', function() {
     assert(matched.result.length === 1, 'no file matched');
   });
 
+  it('should support bare directories', () => {
+    const root = path.resolve(__dirname + '/../fixtures/');
+    process.chdir(root);
+
+    var config = { ignore: ['configs'] };
+    var settings = merge(config, defaults);
+
+    settings.monitor = match.rulesToMonitor(settings.watch, settings.ignore, {
+      dirs: [],
+    });
+
+    var matched = match([root + '/configs/index.js'], settings.monitor, 'js');
+    assert(matched.result.length === 0, 'no files matched');
+  })
+
   it('should support "--watch /some/path/*/config.json"', function() {
     var config = { watch: '/*/config.json' };
     var settings = merge(config, defaults);
@@ -419,8 +440,9 @@ describe('match rule parser', function() {
       system: { useFind: true },
     });
 
+
     var matched = match(['/some/path/to/config.json'], settings.monitor, 'js');
-    assert(matched.result.length === 1, 'no file matched');
+    assert(matched.result.length === 1, 'matched file');
   });
 
   it('should support "--watch *.*"', function() {

--- a/test/monitor/match.test.js
+++ b/test/monitor/match.test.js
@@ -363,7 +363,7 @@ describe('validating files that cause restart', function() {
 describe('match rule parser', function() {
   const pwd = process.cwd();
 
-  after(() => {
+  afterEach(() => {
     process.chdir(pwd);
   });
 


### PR DESCRIPTION
In the previous version, although the restart would ignore, an ignored
directory, if "bare" (i.e. without globs) would still be "monitored" and
potentially take up time. This change ensures the directory is fully
ignored (as well as a small change for fully ignoring files using the
same method).

Now the config.monitor rules is the source of truth for ignoring.

Fixes #1336