### PR TITLE
Remove the special handling of exit code 2

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -158,6 +158,22 @@ function run(options) {
       process.exit();
     }
 
+    if (code === 2 && Date.now() < config.lastStarted + 500) {
+      // something wrong with parsed command
+      utils.log.error('process failed, unhandled exit code (2)');
+      utils.log.error('');
+      utils.log.error('Either the command has a syntax error,');
+      utils.log.error('or it is exiting with reserved code 2.');
+      utils.log.error('');
+      utils.log.error('To keep nodemon running even after a code 2,');
+      utils.log.error('add this to the end of your command: || true');
+      utils.log.error('');
+      utils.log.error('nodemon will stop now so that you can fix the command.');
+      utils.log.error('');
+      bus.emit('error', code);
+      process.exit();
+    }
+
     // In case we killed the app ourselves, set the signal thusly
     if (killedAfterChange) {
       killedAfterChange = false;

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -158,8 +158,10 @@ function run(options) {
       process.exit();
     }
 
+    // If the command failed with code 2, it may or may not be a syntax error
+    // See: http://git.io/fNOAR
+    // We will only assume a parse error, if the child failed quickly
     if (code === 2 && Date.now() < config.lastStarted + 500) {
-      // something wrong with parsed command
       utils.log.error('process failed, unhandled exit code (2)');
       utils.log.error('');
       utils.log.error('Either the command has a syntax error,');
@@ -167,6 +169,7 @@ function run(options) {
       utils.log.error('');
       utils.log.error('To keep nodemon running even after a code 2,');
       utils.log.error('add this to the end of your command: || exit 1');
+      utils.log.error('');
       utils.log.error('Read more here: https://git.io/fNOAG');
       utils.log.error('');
       utils.log.error('nodemon will stop now so that you can fix the command.');

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -158,13 +158,6 @@ function run(options) {
       process.exit();
     }
 
-    if (code === 2) {
-      // something wrong with parsed command
-      utils.log.error('process failed, unhandled exit code (2)');
-      bus.emit('error', code);
-      process.exit();
-    }
-
     // In case we killed the app ourselves, set the signal thusly
     if (killedAfterChange) {
       killedAfterChange = false;

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -166,7 +166,7 @@ function run(options) {
       utils.log.error('or it is exiting with reserved code 2.');
       utils.log.error('');
       utils.log.error('To keep nodemon running even after a code 2,');
-      utils.log.error('add this to the end of your command: || true');
+      utils.log.error('add this to the end of your command: || exit 1');
       utils.log.error('Read more here: https://git.io/fNOAG');
       utils.log.error('');
       utils.log.error('nodemon will stop now so that you can fix the command.');

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -167,6 +167,7 @@ function run(options) {
       utils.log.error('');
       utils.log.error('To keep nodemon running even after a code 2,');
       utils.log.error('add this to the end of your command: || true');
+      utils.log.error('Read more here: https://git.io/fNOAG');
       utils.log.error('');
       utils.log.error('nodemon will stop now so that you can fix the command.');
       utils.log.error('');


### PR DESCRIPTION
This PR removes the special handling of exit code 2.

Not only `mocha` but also `stylelint` will sometimes exit with code 2, resulting in unexpected behaviour from nodemon. (It exits, and stops monitoring.)

The ` || true` workaround is unusual and easy to forget. I only ever remember to add it *after* I have been bitten!

If there is [no special reason](https://github.com/remy/nodemon/issues/627#issuecomment-139053515) to keep the special handling of code 2, then I think it would be best to remove it.

(In the case when a developer does provide a non-parseable command, which exits with code 2, an error is already reported to the console. So we won't be keeping developers in the dark by not quitting. After this PR, the developer will need to hit Ctrl-C to exit nodemon, in order to fix their command. For an example syntax error, try: `nodemon -x 'ls <'`)

Fixes #496 #627

This could perhaps be part of a major release, just in case some people are using it as a way to break out of nodemon intentionally: https://github.com/remy/nodemon/issues/751#issuecomment-267431143