### PR TITLE
fix: send proper quit signal on ctrl-c

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -172,6 +172,7 @@ Additional restart information:
 * Which ignore rules are being applied
 * Which file extensions are being watch
 * The process ID of your application (the `child pid`)
+* The process ID of nodemon to manually trigger restarts via kill signals
 
 For example:
 
@@ -179,6 +180,7 @@ For example:
 14 Apr 15:24:58 - [nodemon] v1.0.17
 14 Apr 15:24:58 - [nodemon] reading config /Users/remy/Sites/jsbin-private/nodemon.json
 14 Apr 15:24:58 - [nodemon] to restart at any time, enter `rs`
+14 Apr 15:24:58 - [nodemon] or send SIGHUP to 58118 to restart
 14 Apr 15:24:58 - [nodemon] ignoring: /Users/remy/Sites/jsbin-private/.git/**/* node_modules/**/node_modules
 14 Apr 15:24:58 - [nodemon] watching: /Users/remy/Sites/jsbin/views/**/* /Users/remy/Sites/jsbin/lib/**/* ../json/*.json config.dev.json
 14 Apr 15:24:58 - [nodemon] watching extensions: json,js,html
@@ -263,13 +265,11 @@ Otherwise see [issue #1124](https://github.com/remy/nodemon/issues/1124) for fur
 
 ## No automatic restart when using Docker volumes [issue #419](https://github.com/remy/nodemon/issues/419#issuecomment-391244911)
 
-Some Node.js Docker images do not seem to have the full suite of filtesystem process utilities that allow `nodemon` to restart automatically when the code in a mounted volume changes. To handle this, and enable automatic restarts without using legacy mode, you can install the [procps](http://procps.sourceforge.net) package. 
+Some Node.js Docker images do not seem to have the full suite of filtesystem process utilities that allow `nodemon` to restart automatically when the code in a mounted volume changes. To handle this, and enable automatic restarts without using legacy mode, you can install the [procps](http://procps.sourceforge.net) package.
 
 Here's an example snippet of a Dockerfile:
 
 ```
 FROM node:8.9.4-wheezy
-RUN apt-get update && apt-get install -y procps 
+RUN apt-get update && apt-get install -y procps
 ```
-
-

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -343,7 +343,11 @@ run.kill = function (flag, callback) {
 };
 run.restart = noop;
 
-bus.on('quit', function onQuit() {
+bus.on('quit', function onQuit(code) {
+  if (code === undefined) {
+    code = 0;
+  }
+
   // remove event listener
   var exitTimer = null;
   var exit = function () {
@@ -357,7 +361,7 @@ bus.on('quit', function onQuit() {
           listener();
         }
       });
-      process.exit(0);
+      process.exit(code);
     } else {
       bus.emit('exit');
     }
@@ -389,7 +393,7 @@ bus.on('restart', function () {
   run.kill();
 });
 
-// remove the flag file on exit
+// remove the child file on exit
 process.on('exit', function () {
   utils.log.detail('exiting');
   if (child) { child.kill(); }
@@ -399,11 +403,10 @@ process.on('exit', function () {
 if (!utils.isWindows) {
   bus.once('boot', () => {
     // usual suspect: ctrl+c exit
-    process.once('SIGINT', () => bus.emit('quit'));
+    process.once('SIGINT', () => bus.emit('quit', 130));
     process.once('SIGTERM', () => {
-      bus.emit('quit');
+      bus.emit('quit', 143);
       if (child) { child.kill('SIGTERM'); }
-      process.exit(0);
     });
   })
 }

--- a/lib/nodemon.js
+++ b/lib/nodemon.js
@@ -115,18 +115,22 @@ function nodemon(settings) {
           if (chr === 13) {
             process.stdout.write('\n');
           }
-          // this prevents cursor keys from working.
+          // this intentionally prevents cursor keys from working.
           process.stdout.write(String.fromCharCode(chr));
         }
 
         if (chr === 3) {
+          if (ctrlC) {
+            process.exit(0);
+          }
+
           // if restartable, assume ctrl+c will break immediately
-          if (ctrlC || rs) {
-            process.exit(rs ? 1 : 0);
+          if (rs) {
+            bus.emit('quit', 130);
           }
           ctrlC = true;
           return;
-        } else if (buffer === '.exit' || chr === 4) { // ctrl+d
+        } else if (!rs && (buffer === '.exit' || chr === 4)) { // ctrl+d
           process.exit();
         } else if (chr === 13 || chr === 10) { // enter / carriage return
           const input = buffer.toString().trim().toLowerCase();
@@ -140,6 +144,7 @@ function nodemon(settings) {
         }
         ctrlC = false;
       });
+      process.stdin.resume();
       if (process.stdin.setRawMode) {
         process.stdin.setRawMode(true);
       }


### PR DESCRIPTION
Fixes #1386

Also sends the correct signal codes on exit - so instead of $?=1 on
ctrl-c, you'll see $?=130 as per http://tldp.org/LDP/abs/html/exitcodes.html