### PR TITLE
fix: revert stdin handling

### DIFF
--- a/lib/nodemon.js
+++ b/lib/nodemon.js
@@ -95,48 +95,43 @@ function nodemon(settings) {
       utils.log.detail('reading config ' + file);
     });
 
-    // echo out notices about running state
-    if (config.options.stdin) {
+    if (config.options.stdin && config.options.restartable) {
+      // allow nodemon to restart when the use types 'rs\n'
+      process.stdin.resume();
+      process.stdin.setEncoding('utf8');
+      process.stdin.on('data', data => {
+        const str = data.toString().trim().toLowerCase();
+
+        // if the keys entered match the restartable value, then restart!
+        if (str === config.options.restartable) {
+          bus.emit('restart');
+        } else if (data.charCodeAt(0) === 12) { // ctrl+l
+          console.clear();
+        }
+      });
+    } else if (config.options.stdin) {
       // so let's make sure we don't eat the key presses
       // but also, since we're wrapping, watch out for
       // special keys, like ctrl+c x 2 or '.exit' or ctrl+d or ctrl+l
       var ctrlC = false;
       var buffer = '';
-      const rs = config.options.restartable;
 
-      process.stdin.setEncoding('utf8');
       process.stdin.on('data', function (data) {
         data = data.toString();
         buffer += data;
         const chr = data.charCodeAt(0);
 
         // if restartable, echo back
-        if (rs) {
-          if (chr === 13) {
-            process.stdout.write('\n');
-          }
-          // this intentionally prevents cursor keys from working.
-          process.stdout.write(String.fromCharCode(chr));
-        }
-
         if (chr === 3) {
           if (ctrlC) {
             process.exit(0);
           }
 
-          // if restartable, assume ctrl+c will break immediately
-          if (rs) {
-            bus.emit('quit', 130);
-          }
           ctrlC = true;
           return;
-        } else if (!rs && (buffer === '.exit' || chr === 4)) { // ctrl+d
+        } else if (buffer === '.exit' || chr === 4) { // ctrl+d
           process.exit();
         } else if (chr === 13 || chr === 10) { // enter / carriage return
-          const input = buffer.toString().trim().toLowerCase();
-          if (input === rs) {
-            bus.emit('restart');
-          }
           buffer = '';
         } else if (chr === 12) { // ctrl+l
           console.clear();
@@ -144,7 +139,6 @@ function nodemon(settings) {
         }
         ctrlC = false;
       });
-      process.stdin.resume();
       if (process.stdin.setRawMode) {
         process.stdin.setRawMode(true);
       }


### PR DESCRIPTION
Fixes #1389
Fixes #1390
Ref #1386

Means that ctrl^l does not instantly clear the terminal. It requires a
new line directly after.