### PR TITLE
docs: update help.txt

### DIFF
--- a/doc/cli/help.txt
+++ b/doc/cli/help.txt
@@ -13,7 +13,7 @@
 
   Note: if the script is omitted, nodemon will try to read "main" from
   package.json and without a nodemon.json, nodemon will monitor .js, .mjs, .coffee,
-  and .litcoffee by default.
+  .litcoffee, and .json by default.
 
   For advanced nodemon configuration use nodemon.json: nodemon --help config
   See also the sample: https://github.com/remy/nodemon/wiki/Sample-nodemon.json


### PR DESCRIPTION
Small update so that `nodemon -h` mentions that `.json` files are now watched by default.

P.S. The change fixing #643 may have been considered as a breaking change, and reflected by bumping major version number. Updating some apps to above nodemon v1.7.0 require adaptation of the config...
P.P.S. Thanks for creating nodemon, super useful piece of software.