### PR TITLE
 fix: properly pass options to chokidar

### DIFF
--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -70,7 +70,7 @@ function watch() {
 
     var watcher = chokidar.watch(
       dirs,
-      Object.assign({}, watchOptions, config.watchOptions || {})
+      Object.assign({}, watchOptions, config.options.watchOptions || {})
     );
 
     watcher.ready = false;

--- a/test/fixtures/configs/watch-options.json
+++ b/test/fixtures/configs/watch-options.json
@@ -1,0 +1,6 @@
+{
+  "ext": "json,js,html",
+  "watchOptions": {
+    "awaitWriteFinish": true
+  }
+}

--- a/test/fork/run-mac-only.test.js
+++ b/test/fork/run-mac-only.test.js
@@ -9,7 +9,7 @@ const filenames = [
   [__dirname + 'some\ \\file', '#!/bin/sh\necho "OK"'],
 ];
 
-if (!process.env.TRAVIS && process.platform !== 'win32') {
+if (!process.env.TRAVIS && process.platform === 'darwin') {
   describe('nodemon fork (mac only)', () => {
     before(() => {
       filenames.map(file => fs.writeFileSync(file[0], file[1], 'utf8'));

--- a/test/monitor/watch.test.js
+++ b/test/monitor/watch.test.js
@@ -1,0 +1,29 @@
+'use-strict';
+
+var assert = require('assert');
+var chokidar = require('chokidar');
+var process = require('process');
+var config = require('../../lib/config');
+var watch = require('../../lib/monitor/watch');
+
+describe('watch', function() {
+  it('should pass watchOptions to the watcher', function(done) {
+    process.chdir(process.cwd() + '/test/fixtures/configs');
+
+    var passedOptions = {};
+    var originalWatch = chokidar.watch;
+    chokidar.watch = function(dirs, options) {
+      passedOptions = options;
+      return originalWatch(dirs, options);
+    };
+
+    config.load({
+      configFile: process.cwd() + '/watch-options.json'
+    }, () => {
+      watch.watch();
+      chokidar.watch = originalWatch;
+      assert(passedOptions.awaitWriteFinish, 'awaitWriteFinish does not have the correct value');
+      done();
+    });
+  });
+})


### PR DESCRIPTION
Fixes #1405 

Also fixed the condition for running `run-mac-only.test.js` since the test suite didn't pass on my Linux computer.