### PR TITLE
fix: change coffeescript name and version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -703,14 +703,11 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
-    "coffee-script": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
-      "integrity": "sha1-YplqhheAx15tUGnROCJyO3NAS/w=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "~0.3.5"
-      }
+    "coffeescript": {
+      "version": "2.3.2",
+      "resolved": "http://registry.npm.taobao.org/coffeescript/download/coffeescript-2.3.2.tgz",
+      "integrity": "sha1-6FSnAg3+R7fPTdQSBC4y7x4mmBA=",
+      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@commitlint/cli": "^3.1.3",
     "@commitlint/config-angular": "^3.1.1",
     "async": "1.4.2",
-    "coffee-script": "~1.7.1",
+    "coffeescript": "~2.3.2",
     "husky": "^0.14.3",
     "istanbul": "^0.4.5",
     "jscs": "^3.0.7",


### PR DESCRIPTION
I found that coffeescript has change its name of repo after a version, and this pull request just change the version and name of coffeescript.
https://github.com/jashkenas/coffeescript