### PR TITLE
fix implementation of psTree.

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -331,7 +331,7 @@ function kill(child, signal, callback) {
     // configured signal (default: SIGUSR2) signal, which fixes #335
     // note that psTree also works if `ps` is missing by looking in /proc
     const sig = signal.replace('SIG', '');
-    psTree(child.pid, function (err, kids) {
+    psTree(child.pid, function (kids) {
       if (psTree.hasPS) {
         spawn('kill', ['-s', sig, child.pid].concat(kids.map(p => p.PID)))
           .on('close', callback);


### PR DESCRIPTION
psTree returns the response tree as the only response param to callback. 
fixes: #1456 #1453 #1455 