### PR TITLE
Add quotes to faq.md

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -13,7 +13,7 @@ In your `nodemon.json` (or in your `package.json`) you can include the follow ev
 ```json
 {
   "events": {
-    "start": "node -e console.clear()"
+    "start": "node -e 'console.clear()'"
   }
 }
 ```


### PR DESCRIPTION
Added quotes around the `console.clear` section of the "How to clear the console on restart" section.