### PR TITLE
feat: Send SIGHUP to application for graceful restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # nodemon
 
-nodemon is a tool that helps develop node.js based applications by automatically restarting the node application when file changes in the directory are detected. 
+nodemon is a tool that helps develop node.js based applications by automatically restarting the node application when file changes in the directory are detected.
 
 nodemon does **not** require *any* additional changes to your code or method of development. nodemon is a replacement wrapper for `node`, to use `nodemon` replace the word `node` on the command line when executing your script.
 
@@ -266,6 +266,23 @@ process.once('SIGUSR2', function () {
 ```
 
 Note that the `process.kill` is *only* called once your shutdown jobs are complete. Hat tip to [Benjie Gillam](http://www.benjiegillam.com/2011/08/node-js-clean-restart-and-faster-development-with-nodemon/) for writing this technique up.
+
+## Configuring your script to gracefully reload instead of terminating
+
+nodemon can send a SIGHUP signal to your application on file update. This signal can be caught, and used to reload configuration in the application.
+
+```bash
+nodemon --sighup
+```
+
+And then in your application
+```js
+process.once('SIGHUP', function () {
+  reloadConfig();
+});
+```
+
+Note: This signal will only be sent to the root process in the application tree. If you would like this signal to be propagated to the entire process tree, please use `--signal`. If you are using node cluster, you can forward the signal to all workers.
 
 ## Triggering events when nodemon state changes
 

--- a/doc/cli/options.txt
+++ b/doc/cli/options.txt
@@ -5,6 +5,7 @@ Configuration
   -i, --ignore ............. ignore specific files or directories
   --no-colors .............. disable color output
   --signal <signal> ........ use specified kill signal instead of default (ex. SIGTERM)
+  --sighup ................. send a SIGHUP signal, allowing graceful reload
   -w, --watch dir........... watch directory "dir" or files. use once for each
                              directory or file to watch
   --no-update-notifier ..... opt-out of update version check

--- a/lib/cli/parse.js
+++ b/lib/cli/parse.js
@@ -192,6 +192,10 @@ function nodemonOption(options, arg, eatNext) {
     options.signal = eatNext();
   } else
 
+  if (arg === '--sighup') {
+    options.gracefulRestart = true;
+  } else
+
   if (arg === '--cwd') {
     options.cwd = eatNext();
 

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -225,7 +225,9 @@ function run(options) {
     }
   });
 
-  run.kill = function (noRestart, callback) {
+  run.kill = config.options.gracefulRestart ? gracefulRestart : killTree;
+
+  function killTree(noRestart, callback) {
     // I hate code like this :(  - Remy (author of said code)
     if (typeof noRestart === 'function') {
       callback = noRestart;
@@ -306,6 +308,20 @@ function run(options) {
   if (config.options.watch !== false) {
     watch();
   }
+}
+
+// Graceful restart will just send a SIGHUP to the main child
+// This is most used for daemons which should reread their config
+function gracefulRestart(flag, callback) {
+  if (!callback) {
+    callback = function () { };
+  }
+
+  if (child) {
+    child.kill('SIGHUP')
+  }
+
+  callback();
 }
 
 function kill(child, signal, callback) {

--- a/test/cli/parse.test.js
+++ b/test/cli/parse.test.js
@@ -245,7 +245,7 @@ describe('nodemon argument parser', function () {
 
 
   it('should support long versions of flags', function () {
-    var settings = cli.parse('node nodemon --version --exec java --verbose --quiet --watch fixtures --ignore fixtures --no-stdin --delay 5 --legacy-watch --exitcrash --on-change-only --ext jade --config my/.nodemon.json --signal SIGHUP');
+    var settings = cli.parse('node nodemon --version --exec java --verbose --quiet --watch fixtures --ignore fixtures --no-stdin --delay 5 --legacy-watch --exitcrash --on-change-only --ext jade --config my/.nodemon.json --signal SIGHUP --sighup');
     assert(settings.version, 'version');
     assert(settings.verbose, 'verbose');
     assert(settings.exec === 'java', 'exec');
@@ -259,6 +259,7 @@ describe('nodemon argument parser', function () {
     assert(settings.ext === 'jade', 'extension is jade');
     assert(settings.configFile === 'my/.nodemon.json', 'custom config file name is my/.nodemon.json');
     assert(settings.signal === 'SIGHUP', 'signal is SIGHUP');
+    assert(settings.gracefulRestart === true, 'gracefulRestart is true');
   });
 });
 


### PR DESCRIPTION
This feature can be used for applications which are already
configured to catch a SIGHUP, and reload their configuration.
Unlike --signal, this does not propagate the signal to all
processes in the process tree, or unpipe stdin.

The command line option --sighup supports this feature