### PR TITLE
fix: `rs` in node@11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
 notifications:
   email: false
 node_js:
-  - '12'
   - '11'
   - '10'
   - '8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ cache:
 notifications:
   email: false
 node_js:
-  - '9'
+  - '12'
+  - '11'
+  - '10'
   - '8'
   - '6'
   - '4'

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -151,7 +151,9 @@ function run(options) {
   });
 
   child.on('exit', function (code, signal) {
-    process.stdin.unpipe(child.stdin);
+    if (child && child.stdin) {
+      process.stdin.unpipe(child.stdin);
+    }
 
     if (code === 127) {
       utils.log.error('failed to start process, "' + cmd.executable +

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -151,6 +151,8 @@ function run(options) {
   });
 
   child.on('exit', function (code, signal) {
+    process.stdin.unpipe(child.stdin);
+
     if (code === 127) {
       utils.log.error('failed to start process, "' + cmd.executable +
         '" exec not found');

--- a/package-lock.json
+++ b/package-lock.json
@@ -4369,9 +4369,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "pstree.remy": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.4.tgz",
-      "integrity": "sha512-3kSyTN/iTJMxtL87idnFgTyOp2vQ6B/49QcHUO26kh2M2qahlUivFI1zWJ9FRFPoB+KgcP820JMOuIhkBJAP3Q=="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.6.tgz",
+      "integrity": "sha512-NdF35+QsqD7EgNEI5mkI/X+UwaxVEbQaz9f4IooEmMUv6ZPmlTQYGjBPJGgrlzNdjSvIy4MWMg6Q6vCgBO2K+w=="
     },
     "punycode": {
       "version": "1.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4369,9 +4369,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "pstree.remy": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.3.tgz",
-      "integrity": "sha512-tGkOSvpMp0j7hskA4izvP0onujJSEAYO0SViHtjJX5a+4cqxVXiq32opahQO4HkA7bnHsRk9xgrf6LVvG/Q9UA=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.4.tgz",
+      "integrity": "sha512-3kSyTN/iTJMxtL87idnFgTyOp2vQ6B/49QcHUO26kh2M2qahlUivFI1zWJ9FRFPoB+KgcP820JMOuIhkBJAP3Q=="
     },
     "punycode": {
       "version": "1.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2367,7 +2367,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
         "create-error-class": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "debug": "^3.1.0",
     "ignore-by-default": "^1.0.1",
     "minimatch": "^3.0.4",
-    "pstree.remy": "^1.1.4",
+    "pstree.remy": "^1.1.6",
     "semver": "^5.5.0",
     "supports-color": "^5.2.0",
     "touch": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "debug": "^3.1.0",
     "ignore-by-default": "^1.0.1",
     "minimatch": "^3.0.4",
-    "pstree.remy": "^1.1.3",
+    "pstree.remy": "^1.1.4",
     "semver": "^5.5.0",
     "supports-color": "^5.2.0",
     "touch": "^3.1.0",


### PR DESCRIPTION
Fixes node 11's `rs` support. Somehow required that the `process.stdin` to be disconnected from the child before the stream is resumed (whereas previously it seemed that it would automatically happen…possibly a node 11 bug).