### PR TITLE
Quote zero-length strings in arguments

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -69,7 +69,7 @@ var utils = (module.exports = {
       args.map(function (arg) {
         // if an argument contains a space, we want to show it with quotes
         // around it to indicate that it is a single argument
-        if (arg.indexOf(' ') === -1) {
+        if (arg.length > 0 && arg.indexOf(' ') === -1) {
           return arg;
         }
         // this should correctly escape nested quotes


### PR DESCRIPTION
If a zero-length string is passed, it does not get properly quoted, and then it is not properly passed to the child process

I noticed this issue when using nodemon to monitor a wrapper script, where i basically pass a bunch of arguments like function arguments.

TODO: update the commit message to fit your convention. I just did this quickly in the github editor.