### PR TITLE
feat: add TypeScript to default execPath

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -7,6 +7,7 @@ module.exports = {
   execMap: {
     py: 'python',
     rb: 'ruby',
+    ts: 'ts-node',
     // more can be added here such as ls: lsc - but please ensure it's cross
     // compatible with linux, mac and windows, or make the default.js
     // dynamically append the `.cmd` for node based utilities


### PR DESCRIPTION
`ts-node` is the standard for running typescript node programs on development mode.

Adding this line will enable everyone with a `tsconfig.json` to have a full-refresh server watching experience. (: