### PR TITLE
feat: Add .tsx extension

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -8,6 +8,7 @@ module.exports = {
     py: 'python',
     rb: 'ruby',
     ts: 'ts-node',
+    tsx: 'ts-node',
     // more can be added here such as ls: lsc - but please ensure it's cross
     // compatible with linux, mac and windows, or make the default.js
     // dynamically append the `.cmd` for node based utilities


### PR DESCRIPTION
### Expected behaviour
```
cross-env NODE_ENV=development nodemon --require ts-node/register -e ts,tsx index.ts
```
The following error occurs when executed as above.
```
/Users/hi/Sites/fe/node_modules/ts-node/src/index.ts:228
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
```

### Actual behaviour
There should be no error.

### Steps to reproduce
It recently added a [feature](https://github.com/remy/nodemon/pull/1552) from 'V1.19.0'. Therefore, if the extension is ts, ts-node can be executed automatically and modified as follows.
```
cross-env NODE_ENV=development nodemon -e ts,tsx index.ts
```
Currently, I use ts/tsx with the project as follows. So in the case of tsx, I have to use register 'ts-node'.
```
cross-env NODE_ENV=development nodemon --require ts-node/register -e ts,tsx index.tsx
```

This feature is awkward to the user. I think both ts and tsx would be better run in ts-node. What do you think?