### PR TITLE
Emit child on start event

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -141,7 +141,7 @@ function run(options) {
     }
   }
 
-  bus.emit('start');
+  bus.emit('start', child);
 
   utils.log.detail('child pid: ' + child.pid);
 


### PR DESCRIPTION
Otherwise I see no way to send messages to the child.
Shouldn't break anything.