### PR TITLE
docs: changed logging and docs to reflect support for single file watching

### DIFF
--- a/doc/cli/help.txt
+++ b/doc/cli/help.txt
@@ -5,7 +5,7 @@
   --config file ............ alternate nodemon.json config file to use
   -e, --ext ................ extensions to look for, ie. js,pug,hbs.
   -x, --exec app ........... execute script with "app", ie. -x "python -v".
-  -w, --watch path.......... watch directory "path" or files. use once for
+  -w, --watch path ......... watch directory "path" or files. use once for
                              each directory or file to watch.
   -i, --ignore ............. ignore specific files or directories.
   -V, --verbose ............ show detail on what is causing restarts.

--- a/doc/cli/options.txt
+++ b/doc/cli/options.txt
@@ -5,7 +5,7 @@ Configuration
   -i, --ignore ............. ignore specific files or directories
   --no-colors .............. disable color output
   --signal <signal> ........ use specified kill signal instead of default (ex. SIGTERM)
-  -w, --watch dir........... watch directory "dir" or files. use once for each
+  -w, --watch path ......... watch directory "dir" or files. use once for each
                              directory or file to watch
   --no-update-notifier ..... opt-out of update version check
 

--- a/lib/nodemon.js
+++ b/lib/nodemon.js
@@ -180,7 +180,7 @@ function nodemon(settings) {
     }).filter(Boolean).join(' ');
     if (ignoring) utils.log.detail('ignoring: ' + ignoring);
 
-    utils.log.info('watching dir(s): ' + config.options.monitor.map(function (rule) {
+    utils.log.info('watching path(s): ' + config.options.monitor.map(function (rule) {
       if (rule.slice(0, 1) !== '!') {
         try {
           rule = path.relative(process.cwd(), rule);


### PR DESCRIPTION
When watching for single files with the `--watch`  or JSON `watch` functionality and with verbose logging enabled, nodemon logs "watching dir(s)" when not all rules may be directories. This initially threw me off to believe that nodemon did _not_ support watching single files, which upon further review, is clearly not the case (i.e. single file works as intended).

Example output:
```
[nodemon] 1.19.4
[nodemon] reading config ./nodemon.json
[nodemon] to restart at any time, enter `rs`
[nodemon] watching dir(s): src/next.config.js src/server.ts
[nodemon] watching extensions: js,ts
[nodemon] starting `yarn run start:development:docker`
[nodemon] spawning
[nodemon] child pid: 44
[nodemon] watching 2 files
```

This pull request fixes these typos to "path(s)" in the verbose logging and "path" in the CLI documentation.