### PR TITLE
test: make sigint test to actually check child pid

### DIFF
--- a/test/fixtures/sigint.js
+++ b/test/fixtures/sigint.js
@@ -1,5 +1,6 @@
 process.on('SIGINT', function() {
-  // do nothing here
+  if (process.argv.length === 3 && process.argv[2] === '--dont-exit') return;
+  process.exit();
 });
 // timer, to keep process running
 setInterval(function() {

--- a/test/misc/sigint.test.js
+++ b/test/misc/sigint.test.js
@@ -6,42 +6,51 @@ var utils = require('../utils'),
     appjs = path.relative(process.cwd(), path.resolve(__dirname, '..', 'fixtures', 'sigint.js')),
     match = utils.match,
     cleanup = utils.cleanup,
-    run = utils.run;
+    run = utils.run,
+    isRunning = utils.isRunning;
+
+function runAndKill(done, cmdline, exitcb)
+{
+  var childPID = null;
+
+  var p = run(cmdline, {
+    output: function (data) {
+      if (match(data, 'pid: ')) {
+        data.replace(/pid: (\d+)/, function (_, p1) {
+          childPID = p1;
+        });
+      }
+    },
+    error: function (data) {
+      assert(false, 'nodemon failed with ' + data);
+      cleanup(p, done);
+    }
+  });
+
+  p.on('message', function (event) {
+    if (event.type === 'start') {
+      setTimeout(function () {
+       p.kill('SIGINT');
+      }, 1000);
+    }
+  }).on('exit', function () {
+    exitcb(childPID);
+  });
+}
 
 describe('terminal signals', function () {
-  it('should kill child with SIGINT (after ~10 seconds)', function (done) {
-    var childPID = null;
-
-    var p = run(appjs, {
-      output: function (data) {
-        if (match(data, 'pid: ')) {
-          data.replace(/pid: (\d+)/, function (m) {
-            childPID = m;
-          });
-        }
-      },
-      error: function (data) {
-        assert(false, 'nodemon failed with ' + data);
-        cleanup(p, done);
-      }
-    });
-
-    p.on('message', function (event) {
-      if (event.type === 'start') {
-        setTimeout(function () {
-          p.kill('SIGINT');
-        }, 1000);
-      }
-    }).on('exit', function () {
-      // check if the child process is still running
-      try {
-        process.kill(childPID, 0);
-        assert(false, 'child is still running at ' + childPID);
-      } catch (e) {
-        assert(true, 'child process was not running');
-      }
+  it('should kill child with SIGINT', function (done) {
+    runAndKill(done, appjs, function (childPID) {
+      assert(!isRunning(childPID), 'child is still running at ' + childPID);
       done();
     });
   });
 
+  it('should terminate nodemon (after ~10 seconds)', function (done) {
+    runAndKill(done, appjs + ' --dont-exit', function (childPID) {
+      // make sure we don't keep abandoned child
+      process.kill(childPID, 'SIGTERM');
+      done();
+    });
+  });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -121,6 +121,16 @@ function getTriggerCount(msg) {
   return changes.pop();
 }
 
+function isRunning(pid) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    if (error.code && error.code === 'ESRCH') return false
+    throw error
+  }
+}
+
 module.exports = {
   getTriggerCount: getTriggerCount,
   Plan: Plan,
@@ -132,4 +142,5 @@ module.exports = {
   appcoffee: appcoffee,
   monitorForChange: monitorForChange,
   port: port,
+  isRunning: isRunning
 };


### PR DESCRIPTION
The aim of this PR is to fix some issues in SIGINT test.
### The problem
Due to combination of the following effects, the SIGINT test does not actually test what it is made for:
1. The callback of `string.replace` method takes the child pid from incorrect parameter:
https://github.com/remy/nodemon/blob/cd45d74593be411eba39481e5a8360c39079b118/test/misc/sigint.test.js#L16-L22
According to [MDN]( https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter), the first parameter contains entire substring, not the first capture group. As the result, the `childPID` contains string, not just number (“pid: 1234”).
2. The test application ignores SIGINT signal and keeps hanging indefinitely:
https://github.com/remy/nodemon/blob/cd45d74593be411eba39481e5a8360c39079b118/test/fixtures/sigint.js#L1-L3
In fact, you can see it in the process list after running tests even if all tests pass.
3. However, the check for child not being running after nodemon exit incorrectly succeeds:
https://github.com/remy/nodemon/blob/cd45d74593be411eba39481e5a8360c39079b118/test/misc/sigint.test.js#L37-L42
This happens because `childPID` is string and `process.kill` requires number and throws an exception. Due to exception, the test code assumes the child is not running and test passes.

### Tested on:
* nodemon: 2.0.2 (from sources in `master`)
* node -v: v12.14.0
* Operating system/terminal environment: Ubuntu 18.04.3 LTS

### The fix
I implemented the following fixes:
1. Changed the test application to only ignore the SIGINT if `--dont-exit` parameter is passed. In all other cases it exits upon receiving SIGINT as any normal application would do.
2. Fixed the parsing of the child pid from the string
3. Implemented more precise checking of the running process
4. Split the test into two: one with child exiting on SIGINT (fast) and another one with child hanging and nodemon still exiting after 10 seconds.

