### PR TITLE
Fix: Can't use --inspect with Typescript code

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -7,7 +7,7 @@ module.exports = {
   execMap: {
     py: 'python',
     rb: 'ruby',
-    ts: 'ts-node',
+    ts: 'node --require ts-node/register',
     // more can be added here such as ls: lsc - but please ensure it's cross
     // compatible with linux, mac and windows, or make the default.js
     // dynamically append the `.cmd` for node based utilities


### PR DESCRIPTION
In `ts-node` project. They stopped support for passing `--inspect` argument. As they declare in readme.
https://github.com/TypeStrong/ts-node#programmatic

> If you need to use advanced node.js CLI arguments (e.g. --inspect), use them with `node -r ts-node/register` instead of the ts-node CLI.

so we can use nodemon like this. `nodemon --inspect ./src/app.ts` without override `nodemon.json` in every project for this one only.