### PR TITLE
fix: fixes issue #1476 after introduced again by version 2.0.2

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -321,7 +321,7 @@ function run(options) {
 function waitForSubProcesses(pid, callback) {
   debug('checking ps tree for pids of ' + pid);
   psTree(pid, (err, pids) => {
-    if (!pids.length) {
+    if (err || !pids.length) {
       return callback();
     }
 
@@ -365,13 +365,12 @@ function kill(child, signal, callback) {
       // the sub processes need to be killed from smallest to largest
       debug('sending kill signal to ' + pids.join(', '));
 
-      child.kill(signal);
-
       pids.sort().forEach(pid => exec(`kill -${sig} ${pid}`, noop));
 
       waitForSubProcesses(child.pid, () => {
         // finally kill the main user process
-        exec(`kill -${sig} ${child.pid}`, callback);
+        child.kill(signal);
+        callback();
       });
 
     });


### PR DESCRIPTION
Hey @remy , seems like issue #1476 was introduced again by version 2.0.2. Please look at my new comment in https://github.com/remy/nodemon/issues/1476#issuecomment-573592914

We have to wait for all subprocess to shutdown before killing the main process. Killing the main process has the side effect of emitting the exit-event, which in turn starts the program again (too early) before the child processes have been terminated.

I updated the test repository to reproduce this error with nodemon@2.0.2 and to test the fix: https://github.com/marcelkottmann/test-nodemon-issue-1476