### PR TITLE
chore: add npm fund field

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "terminal"
   ],
   "license": "MIT",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/nodemon"
+  },
   "main": "./lib/nodemon",
   "scripts": {
     "commitmsg": "commitlint -e",


### PR DESCRIPTION
follow up to #1695

I still think it's a mistake to use `post-install` scripts for ads.
At least this can help move the project in a better direction.