### PR TITLE
Update library to use debug v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1238,9 +1238,9 @@
       }
     },
     "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "version": "4.1.1",
+      "resolved": "https://artifactory.engtools.xoom.com:443/artifactory/api/npm/npmjs-virtual/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
       "requires": {
         "ms": "^2.1.1"
       }
@@ -1663,6 +1663,17 @@
       "dev": true,
       "requires": {
         "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://artifactory.engtools.xoom.com:443/artifactory/api/npm/npmjs-virtual/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "foreach": {
@@ -2414,6 +2425,17 @@
       "requires": {
         "agent-base": "^4.3.0",
         "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://artifactory.engtools.xoom.com:443/artifactory/api/npm/npmjs-virtual/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "husky": {
@@ -3504,8 +3526,8 @@
     },
     "ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "resolved": "https://artifactory.engtools.xoom.com:443/artifactory/api/npm/npmjs-virtual/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
     },
     "mute-stream": {
       "version": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "chokidar": "^3.2.2",
-    "debug": "^3.2.6",
+    "debug": "^4.1.1",
     "ignore-by-default": "^1.0.1",
     "minimatch": "^3.0.4",
     "pstree.remy": "^1.1.7",


### PR DESCRIPTION
debug@3 is no longer mantained. No breaking changes are expected because of this change.