### PR TITLE
Correct entrypoint script path comparison bug

### DIFF
--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -180,9 +180,8 @@ function filterAndRestart(files) {
     if (config.options.execOptions && config.options.execOptions.script) {
       const script = path.relative(cwd, config.options.execOptions.script);
       if (matched.result.length === 0 && script) {
-        const length = script.length;
         files.find(file => {
-          if (file.substr(-length, length) === script) {
+          if (file === script) {
             matched = {
               result: [file],
               total: 1,

--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -178,7 +178,7 @@ function filterAndRestart(files) {
     // if there's no matches, then test to see if the changed file is the
     // running script, if so, let's allow a restart
     if (config.options.execOptions && config.options.execOptions.script) {
-      const script = path.resolve(config.options.execOptions.script);
+      const script = path.relative(cwd, config.options.execOptions.script);
       if (matched.result.length === 0 && script) {
         const length = script.length;
         files.find(file => {


### PR DESCRIPTION
The previously existing logic incorrectly compares an absolute path with a relative path, preventing a change in the entrypoint script from triggering a restart. This PR correctly compares paths relative to cwd, as `files` are represented.