### PR TITLE
fix: ignore ./<path> on cwd

### DIFF
--- a/lib/monitor/match.js
+++ b/lib/monitor/match.js
@@ -157,6 +157,12 @@ function match(files, monitor, ext) {
       if (s.indexOf('!' + cwd) === 0) {
         return s;
       }
+
+      // if it starts with a period, then let's get the relative path
+      if (s.indexOf('!.') === 0) {
+        return '!' + path.resolve(cwd, s.substring(1));
+      }
+
       return '!**' + (prefix !== path.sep ? path.sep : '') + s.slice(1);
     }
 
@@ -195,12 +201,13 @@ function match(files, monitor, ext) {
     for (var i = 0; i < rules.length; i++) {
       if (rules[i].slice(0, 1) === '!') {
         if (!minimatch(file, rules[i], minimatchOpts)) {
+          debug('ignored', file, 'rule:', rules[i]);
           ignored++;
           matched = true;
           break;
         }
       } else {
-        debug('match', file, minimatch(file, rules[i], minimatchOpts));
+        debug('matched', file, 'rule:', rules[i]);
         if (minimatch(file, rules[i], minimatchOpts)) {
           watched++;
 

--- a/test/monitor/match.test.js
+++ b/test/monitor/match.test.js
@@ -22,6 +22,50 @@ describe('match', function() {
     '!*.coffee',
   ];
 
+  it('should resolve ./ in positive match', () => {
+    const cwd = process.cwd();
+    const res = match(
+      [cwd + '/app.nodemon'],
+      [
+        './*.nodemon',
+        '!**/dir/*.nodemon',
+      ],
+      'js,mjs,json,nodemon'
+    );
+
+    assert.equal(res.result.length, 1, JSON.stringify(res));
+  });
+
+  it('should resolve ./ in positive match (miss test)', () => {
+    const cwd = process.cwd();
+    const res = match(
+      [cwd + '/dir/app.nodemon'],
+      [
+        './*.nodemon',
+        '!**/dir/*.nodemon',
+      ],
+      'js,mjs,json,nodemon'
+    );
+
+    assert.equal(res.result.length, 0, JSON.stringify(res));
+    assert.equal(res.ignored, 1, JSON.stringify(res));
+  });
+
+  it('should resolve ./ in negative match (hit test)', () => {
+    const cwd = process.cwd();
+    const res = match(
+      [cwd + '/app.nodemon'],
+      [
+        '!./*.nodemon',
+        '**/dir/*.nodemon',
+      ],
+      'js,mjs,json,nodemon'
+    );
+
+    assert.equal(res.result.length, 0, JSON.stringify(res));
+    assert.equal(res.ignored, 1, JSON.stringify(res));
+  });
+
   it('should handle lots of **s!', () => {
     const res = match(
       ['test/fixtures/app.js'],


### PR DESCRIPTION
Fixes: #1784

This fixes the watch/ignore rules where the config is ignoring
the relative local path of ./ - this fix was in place for the
positive (watch) test but not patched for the negative (ignore).