### PR TITLE
Update run.js to include exit code in crash log

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -239,8 +239,8 @@ function run(options) {
           process.exit(1);
         }
       } else {
-        utils.log.fail('app crashed - waiting for file changes before' +
-          ' starting...');
+        utils.log.fail('app crashed with exit code "' + code + '" - waiting for' +
+          ' file changes before starting...');
         child = null;
       }
     }


### PR DESCRIPTION
In my opinion the crash log should include the exit code