### PR TITLE
docs: delay option as number instead of string, in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Specify the config in the same format as you would for a config file but under `
   "...": "... other standard package.json values",
   "nodemonConfig": {
     "ignore": ["test/*", "docs/*"],
-    "delay": "2500"
+    "delay": 2500
   }
 }
 ```
@@ -247,7 +247,7 @@ If you are setting this value in `nodemon.json`, the value will always be interp
 nodemon --delay 2.5
 
 {
-  "delay": "2500"
+  "delay": 2500
 }
 ```
 


### PR DESCRIPTION
<img width="311" alt="Screenshot 2021-02-07 at 15 14 47" src="https://user-images.githubusercontent.com/1871393/107149135-3d830500-6957-11eb-9ddc-e0ee7f7321c1.png">

Also some IDEs already reporting the wrong type

<img width="651" alt="Screenshot 2021-02-07 at 15 17 01" src="https://user-images.githubusercontent.com/1871393/107149208-a0749c00-6957-11eb-8a4d-6b6ffd540bba.png">

Plus quite problematic in lib/monitor/watch.js