### PR TITLE
fix: allow windows users to install globally again

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -16,6 +16,7 @@ var restart = null;
 var psTree = require('pstree.remy');
 var path = require('path');
 var signals = require('./signals');
+const osRelease = require('os').release();
 
 function run(options) {
   var cmd = config.command.raw;
@@ -312,11 +313,18 @@ function kill(child, signal, callback) {
   }
 
   if (utils.isWindows) {
+    const taskKill = () => {
+      try {
+        exec('taskkill /pid ' + child.pid + ' /T /F');
+      } catch (e) {
+        utils.log.error("Could not shutdown sub process cleanly");
+      }
+    }
 
     // We are handling a 'SIGKILL' POSIX signal under Windows the
     // same way it is handled on a UNIX system: We are performing
     // a hard shutdown without waiting for the process to clean-up.
-    if (signal === 'SIGKILL') {
+    if (signal === 'SIGKILL' || osRelease < 10) {
 
       debug('terminating process group by force: %s', child.pid);
 
@@ -324,7 +332,7 @@ function kill(child, signal, callback) {
       // process group ('/t') of the child ('/pid') by force ('/f').
       // We need to end all sub processes, because the 'child'
       // process in this context is actually a cmd.exe wrapper.
-      exec(`taskkill /f /t /pid ${child.pid}`);
+      taskKill();
       callback();
       return;
     }
@@ -357,9 +365,13 @@ function kill(child, signal, callback) {
     // Therefore we are using 'start' to create a new cmd.exe context.
     // The '/min' option hides the new terminal window and the '/wait'
     // option lets the process wait for the command to finish.
-    execSync(
-      `start "windows-kill" /min /wait "${windowsKill}" -SIGINT ${processId}`
-    );
+    try {
+      execSync(
+        `start "windows-kill" /min /wait "${windowsKill}" -SIGINT ${processId}`
+      );
+    } catch (e) {
+      taskKill();
+    }
     callback();
 
   } else {

--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -347,7 +347,7 @@ function kill(child, signal, callback) {
     // We are using the standalone 'windows-kill' executable to send the
     // standard POSIX signal 'SIGINT' to the node process. This fixes #1720.
     const windowsKill = path.normalize(
-      `${process.cwd()}/node_modules/nodemon/bin/windows-kill.exe`
+      `${__dirname}/../../bin/windows-kill.exe`
     );
 
     // We have to detach the 'windows-kill' execution completely from this


### PR DESCRIPTION
Two fixes:

1. Allow nodemon to be installed globally and use the dep windows-kill
2. Don't use windows kill on Windows@ < 10