### PR TITLE
fix: typo in lib/nodemon.js

### DIFF
--- a/lib/nodemon.js
+++ b/lib/nodemon.js
@@ -98,7 +98,7 @@ function nodemon(settings) {
     });
 
     if (config.options.stdin && config.options.restartable) {
-      // allow nodemon to restart when the use types 'rs\n'
+      // allow nodemon to restart when the user types 'rs\n'
       process.stdin.resume();
       process.stdin.setEncoding('utf8');
       process.stdin.on('data', data => {


### PR DESCRIPTION
Fixed typo from 'use' -> 'user'