### PR TITLE
fix: add windows signals SIGUSR2 & SIGUSR1 to terminate the process

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -333,10 +333,10 @@ function kill(child, signal, callback) {
       }
     };
 
-    // We are handling a 'SIGKILL' POSIX signal under Windows the
+    // We are handling a 'SIGKILL' , 'SIGUSR2' and 'SIGUSR1' POSIX signal under Windows the
     // same way it is handled on a UNIX system: We are performing
     // a hard shutdown without waiting for the process to clean-up.
-    if (signal === 'SIGKILL' || osRelease < 10) {
+    if (signal === 'SIGKILL' || osRelease < 10 || signal === 'SIGUSR2' || signal==="SIGUSR1" ) {
       debug('terminating process group by force: %s', child.pid);
 
       // We are using the taskkill utility to terminate the whole


### PR DESCRIPTION
on SIGUSR2 & SIGUSR1 triggers in windows, we should invoke taskkill 