### PR TITLE
BREAKING CHANGE: patch minimatch so '*.*' matches all files, fix #904

### DIFF
--- a/lib/monitor/match.js
+++ b/lib/monitor/match.js
@@ -1,8 +1,16 @@
-const minimatch = require('minimatch');
+const _minimatch = require('minimatch');
 const path = require('path');
 const fs = require('fs');
 const debug = require('debug')('nodemon:match');
 const utils = require('../utils');
+
+// Monkey patch minimatch so "*.*" matches all files (including those with no extension)
+function minimatch() {
+  const args = Array.prototype.slice.call(arguments);
+  args[1] = args[1].replace('*.*', '*')
+  const res = _minimatch.apply(null, args);
+  return res;
+}
 
 module.exports = match;
 module.exports.rulesToMonitor = rulesToMonitor;


### PR DESCRIPTION
The `--ext '*'` (or `--ext '.'`) option should result in nodemon watching all files - that is, afterall, what the "*" glob generally means - however that's not what happens.  Instead, nodemon just watches files with extensions because, under the hood, it uses the '*.*'  glob.  Why that is, I don't know.

The simplest solution I found for this was to Monkey patch the `minimatch` function so '*.*' was treated like '*'.

... and, yes, I know this is ugly.  Would love some guidance or insight on better ways to solve this problem.