### PR TITLE
chore(std bump): Updated debug's version to 4.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "chokidar": "^3.5.2",
-    "debug": "^3.2.7",
+    "debug": "^4.3.3",
     "ignore-by-default": "^1.0.1",
     "minimatch": "^3.0.4",
     "pstree.remy": "^1.1.8",


### PR DESCRIPTION
There's an issue with debug showing different timestamp formats on different versions. As far as I'm aware it introduces no errors to upgrade.

debug-js/debug#867

@Qix- asked to be mentioned