### PR TITLE
fix: support windows by using path.delimiter

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -64,7 +64,7 @@ function run(options) {
 
   const spawnOptions = {
     env: Object.assign({}, process.env, options.execOptions.env, {
-      PATH: binPath + ':' + process.env.PATH,
+      PATH: binPath + path.delimiter + process.env.PATH,
     }),
     stdio: stdio,
   };


### PR DESCRIPTION
Fixes: #1951

This change was suggested in https://github.com/remy/nodemon/issues/1951#issuecomment-1003362605 and I've verified it fixes the issue.