### PR TITLE
#1989: Fix path to be platform-compliant

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -59,12 +59,13 @@ function run(options) {
 
   var sh = 'sh';
   var shFlag = '-c';
+  const pathSep = utils.isWindows?';':':';
 
-  const binPath = process.cwd() + '/node_modules/.bin';
+  const binPath = path.join(process.cwd() ,'node_modules','.bin');
 
   const spawnOptions = {
     env: Object.assign({}, process.env, options.execOptions.env, {
-      PATH: binPath + ':' + process.env.PATH,
+      PATH: binPath + pathSep + process.env.PATH,
     }),
     stdio: stdio,
   };


### PR DESCRIPTION
This fixes the path on the Windows platform by 
- composing the folder-path in a platform agnostic manner (path.join)
- add the folder-path to the actual environments path with the proper separator