### PR TITLE
fix: resolve path is corrupt when spawning on windows (#1989)

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -59,12 +59,13 @@ function run(options) {
 
   var sh = 'sh';
   var shFlag = '-c';
+  const pathSep = utils.isWindows?';':':';
 
-  const binPath = process.cwd() + '/node_modules/.bin';
+  const binPath = path.join(process.cwd() ,'node_modules','.bin');
 
   const spawnOptions = {
     env: Object.assign({}, process.env, options.execOptions.env, {
-      PATH: binPath + ':' + process.env.PATH,
+      PATH: binPath + pathSep + process.env.PATH,
     }),
     stdio: stdio,
   };

--- a/test/config/env.test.js
+++ b/test/config/env.test.js
@@ -6,6 +6,8 @@ var nodemon = require('../../lib/'),
 
 describe('when nodemon runs (1)', function () {
   var tmp = path.resolve('test/fixtures/env.js');
+  var tmp2 = path.resolve('test/fixtures/path_valid.js');
+
   after(function (done) {
     // clean up just in case.
     nodemon.once('exit', function () {
@@ -16,6 +18,26 @@ describe('when nodemon runs (1)', function () {
   it('should pass through environment values', function (done) {
     nodemon({ script: tmp, stdout: false, env: { USER: 'nodemon' } }).on('stdout', function (data) {
       assert(data.toString().trim() === 'nodemon', 'USER env value correctly set to "nodemon": ' + data.toString());
+      nodemon.once('exit', function () {
+        nodemon.reset(done);
+      }).emit('quit');
+    });
+  });
+
+  it('should pass a valid path in environment when forking', function (done) {
+    // the bug #1989 is triggered when spawning node instead of forking.
+    nodemon({ script : tmp2, stdout: false }).on('stdout', function (data) {
+      assert(data.toString().trim() === 'OK', 'Path in child process should be valid: outcome ' + data.toString());
+      nodemon.once('exit', function () {
+        nodemon.reset(done);
+      }).emit('quit');
+    });
+  });
+
+  it('should pass a valid path in environment when spawning', function (done) {
+    // the bug #1989 is triggered when spawning node instead of forking.
+    nodemon({ script : tmp2, stdout: false, spawn: true }).on('stdout', function (data) {
+      assert(data.toString().trim() === 'OK', 'Path in child process should be valid: outcome ' + data.toString());
       nodemon.once('exit', function () {
         nodemon.reset(done);
       }).emit('quit');

--- a/test/fixtures/path_valid.js
+++ b/test/fixtures/path_valid.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+const process = require('process');
+const path = require('path');
+
+const isWindows = process.platform === 'win32';
+const re = isWindows ? /^[A-Z]:(?:\\[\w&_ .()\-@]+)+\\?$/i : /^(?:\/[\w&_ .()\-@]+)+\/?$/i
+
+console.log(process.env.PATH.split(isWindows?';':':').
+    filter( f => f !=='').map( folder => { let t = path.normalize(folder).match(re); if (!t) {console.log(folder)}; return t;}
+).reduce( (a,b) => a && b , true)? "OK":"FAIL");
+
+


### PR DESCRIPTION
This fixes the issue #1989;
When using the spawn-method, the path was prefixed with the cwd() +'/node_modules/.bin' + ':', resulting on Windows in a corrupt first entry. 
This will largely go unnoticed, until one attempts to execute a program located in that folder. 

The fix composes the folder and adds it to the path in a platform dependent way 
The added tests work on Windows native and WSL2-Ubuntu, but may fail when encountering folders containing extended characters such as é, ä and so on. 
Testing if the folder exists proofed unsuccessful; my path contained several folders that didn't  exist.
Alternately, attempting to launch an (any) executable from the first folder in the path is playing Russian roulette. 