### PR TITLE
chore: remove git.io

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -86,7 +86,7 @@ function run(options) {
         })
         .join(' ');
     }
-    // taken from npm's cli: https://git.io/vNFD4
+    // taken from npm's cli: https://github.com/npm/npm/blob/d46015256941ddfff1463338e3e2f8f77624a1ff/lib/utils/lifecycle.js#L261-L265
     sh = process.env.comspec || 'cmd';
     shFlag = '/d /s /c';
     spawnOptions.windowsVerbatimArguments = true;
@@ -103,7 +103,7 @@ function run(options) {
   } catch (e) {}
 
   // hasStdio allows us to correctly handle stdin piping
-  // see: https://git.io/vNtX3
+  // see: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V6.md#6.4.0
   const hasStdio = utils.satisfies('>= 6.4.0 || < 5');
 
   // forking helps with sub-process handling and tends to clean up better
@@ -192,7 +192,7 @@ function run(options) {
     }
 
     // If the command failed with code 2, it may or may not be a syntax error
-    // See: http://git.io/fNOAR
+    // See: https://github.com/remy/nodemon/pull/1381#issuecomment-405309581
     // We will only assume a parse error, if the child failed quickly
     if (code === 2 && Date.now() < config.lastStarted + 500) {
       utils.log.error('process failed, unhandled exit code (2)');
@@ -203,7 +203,7 @@ function run(options) {
       utils.log.error('To keep nodemon running even after a code 2,');
       utils.log.error('add this to the end of your command: || exit 1');
       utils.log.error('');
-      utils.log.error('Read more here: https://git.io/fNOAG');
+      utils.log.error('Read more here: https://github.com/remy/nodemon/blob/master/faq.md#error-process-failed-unhandled-exit-code-2');
       utils.log.error('');
       utils.log.error('nodemon will stop now so that you can fix the command.');
       utils.log.error('');

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -40,7 +40,7 @@ module.exports = function spawnCommand(command, config, eventArgs) {
         return e;
       }).join(' ');
     });
-    // taken from npm's cli: https://git.io/vNFD4
+    // taken from npm's cli: https://github.com/npm/npm/blob/d46015256941ddfff1463338e3e2f8f77624a1ff/lib/utils/lifecycle.js#L261-L265
     sh = process.env.comspec || 'cmd';
     shFlag = '/d /s /c';
     spawnOptions.windowsVerbatimArguments = true;


### PR DESCRIPTION
### Summary

All links on git.io will stop redirecting after April 29, 2022.

### Other Information

- https://github.blog/changelog/2022-04-25-git-io-deprecation/