### PR TITLE
chore: add unused files to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,8 @@ issues/
 website/
 *.md
 Dockerfile
+.eslintrc.json
+.jshintrc
+.releaserc
+.travis.yml
+commitlint.config.js


### PR DESCRIPTION
Adds the following files to `.npmignore` since they aren't needed in the installed package:
- `.eslintrc.json`
- `.jshintrc`
- `.releaserc`
- `.travis.yml`
- `commitlint.config.js`