### PR TITLE
Fix typo in docs and grammar in website

### DIFF
--- a/doc/events.md
+++ b/doc/events.md
@@ -23,7 +23,7 @@ nodemon will emit events based on the child process.
 - stderr - the stderr stream from the child process
 - readable - stdout and stderr streams are ready ([example](https://github.com/remy/nodemon#pipe-output-to-somewhere-else))
 
-Note that if you want to supress the normal stdout & stderr of the child, in favour
+Note that if you want to suppress the normal stdout & stderr of the child, in favour
 of processing the stream manually using the stdout/stderr nodemon events, pass
 nodemon the option of `stdout: false`.
 

--- a/website/index.html
+++ b/website/index.html
@@ -27,7 +27,7 @@
 
     </header>
     <main>
-      <p>Nodemon is a utility <strong>depended on about 3 million projects</strong>, that will monitor for any
+      <p>Nodemon is a utility <strong>depended on by about 3 million projects</strong>, that will monitor for any
         changes in your source and automatically restart your server.
         Perfect for development.</p>
 


### PR DESCRIPTION
Fixed typo in docs: supress to suppress.

Grammar in website: "nodemon... depended on about 3 million projects" gives the meaning that nodemon is depending on the projects not that the projects are depending on nodemon.