### PR TITLE
Get rid of spawning shell windows if nodemon is started without console.

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -90,6 +90,7 @@ function run(options) {
     sh = process.env.comspec || 'cmd';
     shFlag = '/d /s /c';
     spawnOptions.windowsVerbatimArguments = true;
+    spawnOptions.windowsHide = true;
   }
 
   var args = runCmd ? utils.stringify(executable, cmd.args) : ':';
@@ -122,11 +123,15 @@ function run(options) {
     var forkArgs = cmd.args.slice(1);
     var env = utils.merge(options.execOptions.env, process.env);
     stdio.push('ipc');
-    child = fork(options.execOptions.script, forkArgs, {
+    const forkOptions = {
       env: env,
       stdio: stdio,
       silent: !hasStdio,
-    });
+    };
+    if (utils.isWindows) {
+      forkOptions.windowsHide = true; 
+    }
+    child = fork(options.execOptions.script, forkArgs, forkOptions);
     utils.log.detail('forking');
     debug('fork', sh, shFlag, args);
   } else {

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -44,6 +44,7 @@ module.exports = function spawnCommand(command, config, eventArgs) {
     sh = process.env.comspec || 'cmd';
     shFlag = '/d /s /c';
     spawnOptions.windowsVerbatimArguments = true;
+    spawnOptions.windowsHide = true;
   }
 
   const args = command.join(' ');


### PR DESCRIPTION
If nodemon is started without it's own console (example: via pm2) on Windows, it spawns console windows for it's monitored processes. This should get rid of this behaviour.