### PR TITLE
docs: adjust wording for clarity

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -27,7 +27,7 @@
 
     </header>
     <main>
-      <p>Nodemon is a utility <strong>depended on about 3 million projects</strong>, that will monitor for any
+      <p>Nodemon is a utility <strong>depended on by about 3 million projects</strong>, that will monitor for any
         changes in your source and automatically restart your server.
         Perfect for development.</p>
 


### PR DESCRIPTION
The wording isn't clear on whether 3 million projects depend on Nodemon, or that Nodemon depends on 3 million projects. Adding "by" makes it clear.