### PR TITLE
[WIP] perf: filter by ext on chokidar side

### DIFF
--- a/lib/monitor/match.js
+++ b/lib/monitor/match.js
@@ -244,20 +244,6 @@ function match(files, monitor, ext) {
 
   debug('good', good)
 
-  // finally check the good files against the extensions that we're monitoring
-  if (ext) {
-    if (ext.indexOf(',') === -1) {
-      ext = '**/*.' + ext;
-    } else {
-      ext = '**/*.{' + ext + '}';
-    }
-
-    good = good.filter(function (file) {
-      // only compare the filename to the extension test
-      return minimatch(path.basename(file), ext, minimatchOpts);
-    });
-  } // else assume *.*
-
   var result = good.concat(whitelist);
 
   if (utils.isWindows) {

--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -52,12 +52,14 @@ function watch() {
       ignored.push(dotFilePattern);
     }
 
+    const ext = undefsafe(config, 'options.execOptions.ext') || '';
     var watchOptions = {
       ignorePermissionErrors: true,
       ignored: ignored,
       persistent: true,
       usePolling: config.options.legacyWatch || false,
       interval: config.options.pollingInterval,
+      ext: ext.length > 0 ? ext.split(',') : undefined,
       // note to future developer: I've gone back and forth on adding `cwd`
       // to the props and in some cases it fixes bugs but typically it causes
       // bugs elsewhere (since nodemon is used is so many ways). the final


### PR DESCRIPTION
I noticed that nodemon uses a lot of CPU while watching my current project.

I investigated it and found that it is `chokidar` who consumes lots of resources. I found this issue https://github.com/paulmillr/chokidar/issues/1162.

I looked into the problem through the context of `nodemon` and found that `chokidar` watches all the files even if we are interested in files with specific extensions.

So, I made this change https://github.com/paulmillr/chokidar/pull/1274 and proposed it to the chokidar.

If talking in numbers, before that change, I had watched 29 892 files and had usage of CPU. It started from the range **198** - **203** at the beginning and stoped at level **217** - **219** after 5-10 restarts. if retrieved via `ps -C node -wwo pid,%cpu,%mem,cmd`

After these changes, I started having 20 140 files watched and CPU usage at **173** - **181** at the beginning, which is a noticeable reduction for my system.

@remy and community, if you consider these changes to be a meaningful improvement, please help me get the PR https://github.com/paulmillr/chokidar/pull/1274 merged.

Also, feel free to share your feedback if you see some improvements in the work I did.

Thanks in advance!