### PR TITLE
allow user set PATH

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -64,7 +64,7 @@ function run(options) {
 
   const spawnOptions = {
     env: Object.assign({}, process.env, options.execOptions.env, {
-      PATH: binPath + path.delimiter + process.env.PATH,
+      PATH: binPath + path.delimiter + options.execOptions.env?.PATH || process.env.PATH,
     }),
     stdio: stdio,
   };


### PR DESCRIPTION
currently it is not possible to to set the `PATH` env because nodemon is overwriting it, this pr will first check if the user passed the `PATH` env and use that, otherwise default to `process.env.PATH`