### PR TITLE
Replace Travis badge with GitHub Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ nodemon is a tool that helps develop Node.js based applications by automatically
 nodemon does **not** require *any* additional changes to your code or method of development. nodemon is a replacement wrapper for `node`. To use `nodemon`, replace the word `node` on the command line when executing your script.
 
 [![NPM version](https://badge.fury.io/js/nodemon.svg)](https://npmjs.org/package/nodemon)
-[![Travis Status](https://travis-ci.org/remy/nodemon.svg?branch=master)](https://travis-ci.org/remy/nodemon) [![Backers on Open Collective](https://opencollective.com/nodemon/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/nodemon/sponsors/badge.svg)](#sponsors)
+[![Travis Status](https://github.com/remy/nodemon/actions/workflows/node.js.yml/badge.svg)](https://github.com/remy/nodemon/actions/workflows/node.js.yml) [![Backers on Open Collective](https://opencollective.com/nodemon/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/nodemon/sponsors/badge.svg)](#sponsors)
 
 # Installation
 


### PR DESCRIPTION
It doesn't look like Travis CI is being used anymore and that GitHub Actions is being used for various tasks, so this just replaces the tests badge on the README.

Unfortunately the current test workflow (`node.js.yml`) runs on both PRs and merges to `main`, so if a PR someone opens up fails, the badge also reflects that, so ideally there would be two separate workflows to break out those responsibilities.