### PR TITLE
feat: always use polling on IBM i

### DIFF
--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -69,6 +69,10 @@ function watch() {
       watchOptions.disableGlobbing = true;
     }
 
+    if (utils.isIBMi) {
+      watchOptions.usePolling = true;
+    }
+
     if (process.env.TEST) {
       watchOptions.useFsEvents = false;
     }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -17,6 +17,7 @@ var utils = (module.exports = {
   isWindows: process.platform === 'win32',
   isMac: process.platform === 'darwin',
   isLinux: process.platform === 'linux',
+  isIBMi: require('os').type() === 'OS400',
   isRequired: (function () {
     var p = module.parent;
     while (p) {


### PR DESCRIPTION
IBM i does not support fs.watch

https://nodejs.org/api/fs.html#caveats

Therefore we always want to use polling on IBM i systems