### PR TITLE
Update release.yml to use ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
The latest release job failed https://github.com/remy/nodemon/actions/runs/5484732578 because it couldn't find any runner.
<img width="991" alt="image" src="https://github.com/remy/nodemon/assets/4157103/55fffe9f-4e8c-42be-9879-83facb495d76">

Since the other jobs run on ubuntu-latest, I imagine this would unblock the release
