### PR TITLE
feat: Enable nodemon to monitor file removal

### DIFF
--- a/lib/monitor/watch.js
+++ b/lib/monitor/watch.js
@@ -87,6 +87,7 @@ function watch() {
     var total = 0;
 
     watcher.on('change', filterAndRestart);
+    watcher.on('unlink', filterAndRestart);
     watcher.on('add', function (file) {
       if (watcher.ready) {
         return filterAndRestart(file);


### PR DESCRIPTION
This change enables nodemon to watch for file removal events. I tested it on a simple app which enables creation and deletion of JSON files while reflecting changes in the GUI. The change does not appear to cause any issues, although I did not perform extensive tests.