### PR TITLE
add Usage Trend to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,9 @@ The answer is simple, but possibly frustrating. I'm not saying (how I pronounce 
 
 Nodemon is not perfect, and CLI arguments has sprawled beyond where I'm completely happy, but perhaps it can be reduced a little one day.
 
+## Usage Trend
+[The usage trend of nodemon and similar packages](https://npm-compare.com/forever,nodemon,pm2)
+
 ## FAQ
 
 See the [FAQ](https://github.com/remy/nodemon/blob/master/faq.md) and please add your own questions if you think they would help others.


### PR DESCRIPTION
I wanted to reach out as an active user of the fantastic "nodemon" npm package. Firstly, I appreciate all the effort you've put into developing and maintaining this tool – it has been an essential part of my workflow.

I have a suggestion that could potentially enhance the user experience for both existing and new users of "nodemon". I propose adding a link to an insightful tool comparison page on npm-compare.com, specifically comparing "forever", "nodemon", and "pm2". This comparison will allow them to make more informed decisions and choose the tool that best aligns with their requirements.

Please consider accepting my pull request to include the link. I would be more than happy to help and contribute further to the project, if needed.