### PR TITLE
Fix types for export on ESModule

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -138,4 +138,4 @@ export interface WatchOptions {
 
 const nodemon: Nodemon = (settings: NodemonSettings): Nodemon => {};
 
-export default nodemon;
+export = nodemon;


### PR DESCRIPTION
Fix types for export in file index.d.ts

- use typescript
- set `"type": "module"` in package.json or set extention file to .mts
```
import nodemon from 'nodemon';

// no show error on ide and also when compile the code
// but error when running
nodemon.default();

// show error on ide and also when compile the code
// but no error when running
nodemon();
```