### PR TITLE
fix: script.start with missing file

### DIFF
--- a/lib/config/exec.js
+++ b/lib/config/exec.js
@@ -25,6 +25,12 @@ function execFromPackage() {
     }
 
     if (pkg.scripts && pkg.scripts.start) {
+      const parts = pkg.scripts.start.split(' ');
+
+      // fixes a loop issue where the script repeats over and over #2258
+      if (parts.includes('nodemon')) {
+        return null;
+      }
       return { exec: pkg.scripts.start };
     }
   } catch (e) {}


### PR DESCRIPTION
Fixes #2258

The issue was that the scripts couldn't be found, so it was just trying to repeatedly read it from scripts.start.

Now if nodemon is in the scripts.start command it exits out the logic.