### PR TITLE
fix: don't exit on code 2 from a long-running process

### DIFF
--- a/lib/monitor/run.js
+++ b/lib/monitor/run.js
@@ -48,6 +48,12 @@ function run(options) {
 
   config.lastStarted = Date.now();
 
+  // capture the start time of *this* child locally: config.lastStarted is
+  // also overwritten by the watcher on every file-change event, so it can't
+  // be trusted to measure how long the child has been running (the exit
+  // handler below uses it to detect an instant startup failure)
+  const childStarted = config.lastStarted;
+
   var stdio = ['pipe', 'pipe', 'pipe'];
 
   if (config.options.stdout) {
@@ -203,7 +209,7 @@ function run(options) {
     // If the command failed with code 2, it may or may not be a syntax error
     // See: http://git.io/fNOAR
     // We will only assume a parse error, if the child failed quickly
-    if (code === 2 && Date.now() < config.lastStarted + 500) {
+    if (code === 2 && Date.now() < childStarted + 500) {
       utils.log.error('process failed, unhandled exit code (2)');
       utils.log.error('');
       utils.log.error('Either the command has a syntax error,');

--- a/test/monitor/run.test.js
+++ b/test/monitor/run.test.js
@@ -166,6 +166,33 @@ describe('when nodemon runs (2)', function () {
       }, 1500);
     });
 
+  it('should treat a late exit code 2 as a crash even if an unwatched file ' +
+    'changed just before it', function (done) {
+    var trigger = path.resolve('test/fixtures/test' + rnd() + '.txt');
+
+    // the script runs well past the 500ms "fast fail" window, then writes a
+    // file that doesn't match the watched extensions (so no restart happens)
+    // and exits with code 2 shortly after. nodemon used to misread this as an
+    // instant startup failure (because the watcher reset config.lastStarted)
+    // and shut itself down instead of waiting for changes.
+    var script = 'var fs = require("fs");\n' +
+      'setTimeout(function () {\n' +
+      '  fs.writeFileSync(' + JSON.stringify(trigger) + ', "x");\n' +
+      '  setTimeout(function () { process.exit(2); }, 400);\n' +
+      '}, 1500);\n';
+    fs.writeFileSync(tmp, script);
+
+    nodemon({ script: tmp, stdout: false }).on('crash', function () {
+      assert(true, 'late exit code 2 treated as a crash, nodemon kept alive');
+      if (fs.existsSync(trigger)) {
+        fs.unlinkSync(trigger);
+      }
+      nodemon.once('exit', function () {
+        nodemon.reset(done);
+      }).emit('quit');
+    });
+  });
+
   it('should kill child on SIGINT', function (done) {
     fs.writeFileSync(tmp, 'setTimeout(function () { var n = 10; }, 10000)');
 


### PR DESCRIPTION
Ran into this while working on a project: nodemon would sometimes just quit with the "unhandled exit code (2)" message even though my app had been running fine for a long time.

Took a while to track down. The exit handler uses `Date.now() < config.lastStarted + 500` to decide whether the process died right after startup (the "syntax error" heuristic). But `watch.js` resets `config.lastStarted` on *every* change event, including files that don't match any watch rule and don't trigger a restart. So if the app writes a log file and then happens to exit with code 2 within half a second, nodemon thinks the command itself is broken and stops completely instead of waiting for file changes.

The fix just keeps the real start time in a local variable inside `run()` so the watcher can't clobber it. I left the assignment in `watch.js` alone because `runOnChangeOnly` relies on it.

Also added a test that reproduces the scenario (app runs 1.5s, writes a .txt, exits with 2) - it fails on main and passes with this change. Verified that a script exiting with code 2 immediately on startup still stops nodemon like before.